### PR TITLE
Remove repeated values from bOnly

### DIFF
--- a/mathutil/sets.go
+++ b/mathutil/sets.go
@@ -1,21 +1,25 @@
 package mathutil
 
-// ComplementsInt takes two int64 slices, and returns the complements of the
-// two lists.
+// ComplementsInt takes two int64 slices, and returns the complements of the two
+// lists removing repeated values.
 func ComplementsInt(a, b []int64) (aOnly, bOnly []int64) {
 	aMap := make(map[int64]struct{}, len(a))
 	for _, i := range a {
 		aMap[i] = struct{}{}
 	}
+	bMap := make(map[int64]struct{}, len(b))
 	for _, i := range b {
 		if _, ok := aMap[i]; ok {
 			delete(aMap, i)
 		} else {
-			bOnly = append(bOnly, i)
+			bMap[i] = struct{}{}
 		}
 	}
 	for i := range aMap {
 		aOnly = append(aOnly, i)
+	}
+	for i := range bMap {
+		bOnly = append(bOnly, i)
 	}
 	return aOnly, bOnly
 }

--- a/mathutil/sets_test.go
+++ b/mathutil/sets_test.go
@@ -48,6 +48,13 @@ func TestComplementsInt(t *testing.T) {
 			aExpected: []int64{1, 2},
 			bExpected: []int64{5, 6},
 		},
+		{
+			name:      "Overlap with repeated values",
+			a:         []int64{6, 4, 5, 3, 6},
+			b:         []int64{2, 1, 4, 3, 1},
+			aExpected: []int64{5, 6},
+			bExpected: []int64{1, 2},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -61,5 +68,32 @@ func TestComplementsInt(t *testing.T) {
 				t.Errorf("B differs:\n%s", d)
 			}
 		})
+	}
+}
+
+func BenchmarkComplementsInt_equal(b *testing.B) {
+	listA := []int64{1, 2, 3}
+	listB := []int64{1, 2, 3}
+
+	for n := 0; n < b.N; n++ {
+		ComplementsInt(listA, listB)
+	}
+}
+
+func BenchmarkComplementsInt_disjoint(b *testing.B) {
+	listA := []int64{1, 2, 3}
+	listB := []int64{5, 6, 7}
+
+	for n := 0; n < b.N; n++ {
+		ComplementsInt(listA, listB)
+	}
+}
+
+func BenchmarkComplementsInt_overlap(b *testing.B) {
+	listA := []int64{1, 2, 3, 4}
+	listB := []int64{3, 4, 5, 6}
+
+	for n := 0; n < b.N; n++ {
+		ComplementsInt(listA, listB)
 	}
 }


### PR DESCRIPTION
To keep the same behavior on the returned slices of the ComplementsInt
function, we should remove the repeated values from the `bOnly` slice.

We used the same approach of the `aOnly` slice, using a map to guarantee only
unique elements. The downside is a worse performance as shown below.

Before:
```
BenchmarkComplementsInt_equal-8    10000000 217 ns/op   0 B/op  0 allocs/op
BenchmarkComplementsInt_disjoint-8  3000000 484 ns/op 160 B/op  8 allocs/op
BenchmarkComplementsInt_overlap-8   3000000 498 ns/op  96 B/op  6 allocs/op
```

After:
```
BenchmarkComplementsInt_equal-8     5000000 255 ns/op   0 B/op  0 allocs/op
BenchmarkComplementsInt_disjoint-8  2000000 769 ns/op 208 B/op 10 allocs/op
BenchmarkComplementsInt_overlap-8   2000000 717 ns/op 144 B/op  8 allocs/op
```