### PR TITLE
Add syncutil.Wait

### DIFF
--- a/syncutil/syncutil.go
+++ b/syncutil/syncutil.go
@@ -1,0 +1,24 @@
+// Package syncutil adds functions for synchronization.
+package syncutil
+
+import (
+	"context"
+	"sync"
+)
+
+// Wait for a sync.WaitGroup with support for timeout/cancellations from
+// context.
+func Wait(ctx context.Context, wg *sync.WaitGroup) error {
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		wg.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-ch:
+		return nil
+	}
+}

--- a/syncutil/syncutil_test.go
+++ b/syncutil/syncutil_test.go
@@ -1,0 +1,45 @@
+package syncutil
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWait(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	t.Run("cancel", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := Wait(ctx, &wg)
+		if err != context.Canceled {
+			t.Errorf("wrong error: %v", err)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		err := Wait(ctx, &wg)
+		if err != context.DeadlineExceeded {
+			t.Errorf("wrong error: %v", err)
+		}
+	})
+
+	t.Run("finish", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		wg.Done()
+		wg.Done()
+
+		err := Wait(ctx, &wg)
+		if err != nil {
+			t.Errorf("wrong error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This is a small helper function to add timeouts to `Waitgroup.Wait`.
It's not terrible complicated, but took some thought to get it right. A
helper function is useful, IMHO, and leads to clearer code for callers.