### PR TITLE
Remove support for dates in the past for MonthsTo

### DIFF
--- a/timeutil/timeutil.go
+++ b/timeutil/timeutil.go
@@ -33,13 +33,13 @@ func FormatAsZulu(t time.Time) string {
 	return t.Format("2006-01-02T15:04:05Z")
 }
 
-// MonthsTo returns the number of months from the current date the given date.
-//
-// The number of months is always rounded down, with a minimal value of 1.
+// MonthsTo returns the number of months from the current date to the given
+// date. The number of months is always rounded down, with a minimal value of 1.
 //
 // For example this returns 2:
-//
 //     MonthsTo(time.Now().Add(24 * time.Hour * 70))
+//
+// Dates in the past are not supported, and their behaviour is undefined!
 func MonthsTo(a time.Time) int {
 	var days int
 	startDate := time.Now()

--- a/timeutil/timeutil_test.go
+++ b/timeutil/timeutil_test.go
@@ -65,11 +65,11 @@ func TestMonthsTo(t *testing.T) {
 		{time.Now(), 1},
 		{time.Now().Add(day * 35), 1},
 		{time.Now().Add(day * 65), 2},
-		{time.Now().Add(-day * 35), -1},
-		{time.Now().Add(-day * 65), -2},
 		{time.Now().Add(day * 370), 12},
 
 		// Broken!
+		//{time.Now().Add(-day * 35), -1},
+		//{time.Now().Add(-day * 65), -2},
 		//{time.Now().Add(-day * 370), -12},
 	}
 


### PR DESCRIPTION
Seems to not work anymore? Fix isn't immediately obvious, and we never
use it with negative dates, so remove the tests and document that the
behaviour is undefined.