### PR TITLE
Never return a nil slice in sqlutil.{Int,String}List

### DIFF
--- a/sqlutil/sqlutil.go
+++ b/sqlutil/sqlutil.go
@@ -26,7 +26,7 @@ func (l *IntList) Scan(v interface{}) error {
 	if v == nil {
 		return nil
 	}
-	var ints []int64
+	ints := []int64{}
 	for _, i := range strings.Split(fmt.Sprintf("%s", v), ",") {
 		i = strings.TrimSpace(i)
 		if i == "" {
@@ -62,7 +62,7 @@ func (l *StringList) Scan(v interface{}) error {
 	if v == nil {
 		return nil
 	}
-	var strs []string
+	strs := []string{}
 	for _, s := range strings.Split(fmt.Sprintf("%s", v), ",") {
 		s = strings.TrimSpace(s)
 		if s == "" {

--- a/sqlutil/sqlutil_test.go
+++ b/sqlutil/sqlutil_test.go
@@ -13,7 +13,7 @@ func TestIntListValue(t *testing.T) {
 		in   IntList
 		want string
 	}{
-		{*new(IntList), ""},
+		{IntList{}, ""},
 		{IntList{}, ""},
 		{IntList{4, 5}, "4, 5"},
 		{IntList{1, 1}, "1, 1"},
@@ -40,7 +40,7 @@ func TestIntListScan(t *testing.T) {
 		want    IntList
 		wantErr string
 	}{
-		{"", *new(IntList), ""},
+		{"", IntList{}, ""},
 		{"1", IntList{1}, ""},
 		{"4, 5", IntList{4, 5}, ""},
 		{"4,   5", IntList{4, 5}, ""},
@@ -73,7 +73,7 @@ func TestStringListValue(t *testing.T) {
 		in   StringList
 		want string
 	}{
-		{*new(StringList), ""},
+		{StringList{}, ""},
 		{StringList{}, ""},
 		{StringList{"4", "5"}, "4,5"},
 		{StringList{"1", "1"}, "1,1"},
@@ -101,7 +101,7 @@ func TestStringListScan(t *testing.T) {
 		want    StringList
 		wantErr string
 	}{
-		{"", *new(StringList), ""},
+		{"", StringList{}, ""},
 		{"1", StringList{"1"}, ""},
 		{"4, 5", StringList{"4", "5"}, ""},
 		{"1, 1", StringList{"1", "1"}, ""},


### PR DESCRIPTION
The issue is that this will get marshaled to `null` in JSON, instead of
`[]`, which makes things more difficult to handle. Apparently this is a
feature:
https://github.com/golang/go/commit/48c75c5f9c8e97b87fbd8f24dffa73d6b2148691

This is the easiest fix, at the expense of a few kb of extra memory
usage.