### PR TITLE
Add func to remove unprintable chars

### DIFF
--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -1,6 +1,8 @@
 // Package stringutil adds functions for working with strings.
 package stringutil
 
+import "regexp"
+
 // Left returns the "n" left characters of the string.
 //
 // If the string is shorter than "n" it will return the first "n" characters of
@@ -13,4 +15,13 @@ func Left(s string, n int) string {
 		return s
 	}
 	return s[:n] + "…"
+}
+
+// RemoveUnprintable removes unprintable characters (0 to 31 ASCII) from a string.
+func RemoveUnprintable(s string) (string, error) {
+	r, err := regexp.Compile("[\x00-\x1F]")
+	if err != nil {
+		return s, err
+	}
+	return r.ReplaceAllString(s, ""), nil
 }

--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -19,7 +19,7 @@ func Left(s string, n int) string {
 
 // RemoveUnprintable removes unprintable characters (0 to 31 ASCII) from a string.
 func RemoveUnprintable(s string) (string, error) {
-	r, err := regexp.Compile("[\x00-\x1F]")
+	r, err := regexp.Compile("[\x00-\x1F]|[\u200e-\u200f]")
 	if err != nil {
 		return s, err
 	}

--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -17,11 +17,9 @@ func Left(s string, n int) string {
 	return s[:n] + "…"
 }
 
+var reUnprintable = regexp.MustCompile("[\x00-\x1F\u200e\u200f]")
+
 // RemoveUnprintable removes unprintable characters (0 to 31 ASCII) from a string.
-func RemoveUnprintable(s string) (string, error) {
-	r, err := regexp.Compile("[\x00-\x1F]|[\u200e-\u200f]")
-	if err != nil {
-		return s, err
-	}
-	return r.ReplaceAllString(s, ""), nil
+func RemoveUnprintable(s string) string {
+	return reUnprintable.ReplaceAllString(s, "")
 }

--- a/stringutil/stringutil_test.go
+++ b/stringutil/stringutil_test.go
@@ -28,3 +28,32 @@ func TestLeft(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveUnprintable(t *testing.T) {
+	cases := []struct {
+		in      string
+		lenLost int
+		want    string
+	}{
+		{"Hello, 世界", 0, "Hello, 世界"},
+		{"m", 1, "m"},
+		{"m", 0, "m"},
+		{" ", 3, " "},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			out, err := RemoveUnprintable(tc.in)
+			if err != nil {
+				t.Error(err)
+			}
+			charsRemoved := len(tc.in) - len(out)
+			if tc.lenLost != charsRemoved {
+				t.Errorf("\ncharsRemoved:  %#v\nwant: %#v\n", charsRemoved, tc.lenLost)
+			}
+			if out != tc.want {
+				t.Errorf("\nout:  %#v\nwant: %#v\n", out, tc.want)
+			}
+		})
+	}
+}

--- a/stringutil/stringutil_test.go
+++ b/stringutil/stringutil_test.go
@@ -44,10 +44,7 @@ func TestRemoveUnprintable(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
-			out, err := RemoveUnprintable(tc.in)
-			if err != nil {
-				t.Error(err)
-			}
+			out := RemoveUnprintable(tc.in)
 			charsRemoved := len(tc.in) - len(out)
 			if tc.lenLost != charsRemoved {
 				t.Errorf("\ncharsRemoved:  %#v\nwant: %#v\n", charsRemoved, tc.lenLost)

--- a/stringutil/stringutil_test.go
+++ b/stringutil/stringutil_test.go
@@ -39,6 +39,7 @@ func TestRemoveUnprintable(t *testing.T) {
 		{"m", 1, "m"},
 		{"m", 0, "m"},
 		{" ", 3, " "},
+		{"a‎b‏c", 6, "abc"}, // only 2 removed but count as 3 each
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
We've had a couple of customers failing to log in cause they copy-pasted/autofilled emails and such with vertical tabs and whatnot in the login fields. 😄 

Probably worth sanitising most inputs with this, hence adding it to `utils` rather than just `launchpad` 🤔 