### PR TITLE
Add goutil

### DIFF
--- a/goutil/goutil.go
+++ b/goutil/goutil.go
@@ -1,0 +1,115 @@
+// Package goutil provides functions to work with Go source files.
+package goutil // import "github.com/teamwork/utils/goutil"
+
+import (
+	"errors"
+	"go/build"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Expand a list of package and/or directory names to Go package names.
+//
+//  - "./example" is expanded to "full/package/path/example".
+//  - "/absolute/src/package/path" is abbreviated to "package/path".
+//  - "full/package" is kept-as is.
+//  - "package/path/..." will include "package/path" and all subpackages.
+//
+// The packages will be sorted with duplicate packages removed. The /vendor/
+// directory is automatically ignored.
+func Expand(paths []string) ([]*build.Package, error) {
+	var out []*build.Package
+	seen := make(map[string]struct{})
+	for _, p := range paths {
+		if strings.HasSuffix(p, "/...") {
+			subPkgs, err := ResolveWildcard(p)
+			if err != nil {
+				return nil, err
+			}
+			for _, sub := range subPkgs {
+				if _, ok := seen[sub.ImportPath]; !ok {
+					out = append(out, sub)
+					seen[sub.ImportPath] = struct{}{}
+				}
+			}
+			continue
+		}
+
+		pkg, err := ResolvePackage(p)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[pkg.ImportPath]; !ok {
+			out = append(out, pkg)
+			seen[pkg.ImportPath] = struct{}{}
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].ImportPath < out[j].ImportPath })
+
+	return out, nil
+}
+
+// ResolvePackage resolves a package path, which can either be a local directory
+// relative to the current dir (e.g. "./example"), a full path (e.g.
+// ~/go/src/example"), or a package path (e.g. "example").
+func ResolvePackage(path string) (pkg *build.Package, err error) {
+	if len(path) == 0 {
+		// TODO: maybe resolve like '.'? Dunno what makes more sense.
+		return nil, errors.New("cannot resolve empty string")
+	}
+
+	switch path[0] {
+	case '/':
+		pkg, err = build.ImportDir(path, build.FindOnly)
+	case '.':
+		path, err = filepath.Abs(path)
+		if err != nil {
+			return nil, err
+		}
+		pkg, err = build.ImportDir(path, build.FindOnly)
+	default:
+		pkg, err = build.Import(path, ".", build.FindOnly)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return pkg, err
+}
+
+// ResolveWildcard finds all subpackages in the "example/..." format. The
+// "/vendor/" directory will be ignored.
+func ResolveWildcard(path string) ([]*build.Package, error) {
+	root, err := ResolvePackage(path[:len(path)-4])
+	if err != nil {
+		return nil, err
+	}
+
+	// Gather a list of directories with *.go files.
+	goDirs := make(map[string]struct{})
+	err = filepath.Walk(root.Dir, func(path string, info os.FileInfo, err error) error {
+		if !strings.HasSuffix(path, ".go") || info.IsDir() || strings.Contains(path, "/vendor/") {
+			return nil
+		}
+
+		goDirs[filepath.Dir(path)] = struct{}{}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*build.Package
+	for d := range goDirs {
+		pkg, err := ResolvePackage(d)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, pkg)
+	}
+
+	return out, nil
+}

--- a/goutil/goutil_test.go
+++ b/goutil/goutil_test.go
@@ -1,0 +1,123 @@
+package goutil
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/teamwork/test"
+)
+
+// This also tests ResolvePackage() and ResolveWildcard().
+func TestExpand(t *testing.T) {
+	cases := []struct {
+		in      []string
+		want    []string
+		wantErr string
+	}{
+		{
+			[]string{"fmt"},
+			[]string{"fmt"},
+			"",
+		},
+		{
+			[]string{"fmt", "fmt"},
+			[]string{"fmt"},
+			"",
+		},
+		{
+			[]string{"fmt", "net/http"},
+			[]string{"fmt", "net/http"},
+			"",
+		},
+		{
+			[]string{"net/..."},
+			[]string{"net", "net/http", "net/http/cgi", "net/http/cookiejar",
+				"net/http/fcgi", "net/http/httptest", "net/http/httptrace",
+				"net/http/httputil", "net/http/internal", "net/http/pprof",
+				"net/internal/socktest", "net/mail", "net/rpc", "net/rpc/jsonrpc",
+				"net/smtp", "net/textproto", "net/url",
+			},
+			"",
+		},
+		{
+			[]string{"github.com/teamwork/utils"},
+			[]string{"github.com/teamwork/utils"},
+			"",
+		},
+		{
+			[]string{"."},
+			[]string{"github.com/teamwork/utils/goutil"},
+			"",
+		},
+		{
+			[]string{".."},
+			[]string{"github.com/teamwork/utils"},
+			"",
+		},
+		{
+			[]string{"../..."},
+			[]string{
+				"github.com/teamwork/utils",
+				"github.com/teamwork/utils/aesutil",
+				"github.com/teamwork/utils/byteutil",
+				"github.com/teamwork/utils/goutil",
+				"github.com/teamwork/utils/httputilx",
+				"github.com/teamwork/utils/httputilx/header",
+				"github.com/teamwork/utils/ioutilx",
+				"github.com/teamwork/utils/jsonutil",
+				"github.com/teamwork/utils/maputil",
+				"github.com/teamwork/utils/mathutil",
+				"github.com/teamwork/utils/netutil",
+				"github.com/teamwork/utils/sliceutil",
+				"github.com/teamwork/utils/sqlutil",
+				"github.com/teamwork/utils/stringutil",
+				"github.com/teamwork/utils/syncutil",
+				"github.com/teamwork/utils/timeutil",
+			},
+			"",
+		},
+
+		// Errors
+		{
+			[]string{""},
+			nil,
+			"cannot resolve empty string",
+		},
+		{
+			[]string{"this/will/never/exist"},
+			nil,
+			`cannot find package "this/will/never/exist"`,
+		},
+		{
+			[]string{"this/will/never/exist/..."},
+			nil,
+			`cannot find package "this/will/never/exist"`,
+		},
+		{
+			[]string{"./doesnt/exist"},
+			nil,
+			"cannot find package",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			out, err := Expand(tc.in)
+			if !test.ErrorContains(err, tc.wantErr) {
+				t.Fatal(err)
+			}
+
+			sort.Strings(tc.want)
+			var outPkgs []string
+			for _, p := range out {
+				outPkgs = append(outPkgs, p.ImportPath)
+			}
+
+			if !reflect.DeepEqual(tc.want, outPkgs) {
+				t.Errorf("\nout:  %#v\nwant: %#v\n", outPkgs, tc.want)
+			}
+		})
+	}
+}

--- a/syncutil/syncutil.go
+++ b/syncutil/syncutil.go
@@ -1,5 +1,5 @@
 // Package syncutil adds functions for synchronization.
-package syncutil // import "github.com/teamwork/syncutil"
+package syncutil // import "github.com/teamwork/utils/syncutil"
 
 import (
 	"context"


### PR DESCRIPTION
Extracted from Kommentaar. Surprisingly, there isn't a standard function
you can call for this. All this logic is "hidden" inside the
cmd/go/internal/load package (which we can't use, as it's internal).

This will also be useful in e.g. godocgen (use `go list` for that, which
works but is ugly).