### PR TITLE
Add more functions to timeutil

### DIFF
--- a/timeutil/timeutil.go
+++ b/timeutil/timeutil.go
@@ -1,3 +1,4 @@
+// Package timeutil provides helpers for working with time.Time.
 package timeutil // import "github.com/teamwork/utils/timeutil"
 
 import "time"
@@ -13,16 +14,39 @@ func DaysBetween(fromDate, toDate time.Time) int {
 	return int(toDate.Sub(fromDate) / (24 * time.Hour))
 }
 
-// StartOfMonth returns the first day of the month of date.
-func StartOfMonth(date time.Time) time.Time {
-	return time.Date(date.Year(), date.Month(), 1, 0, 0, 0, 0, date.Location())
+// StartOfDay returns the start of t's day.
+func StartOfDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 }
 
-// EndOfMonth returns the last day of the month of date.
-func EndOfMonth(date time.Time) time.Time {
+// EndOfDay returns the end of t's day.
+func EndOfDay(t time.Time) time.Time {
+	// Finding the end of the day is tricky, due to leap seconds (We can't
+	// assume that 23:59:59 is the last second--or that it even happens on any
+	// given day due to negative leap seconds) and DST.
+	//
+	// The strategy here is to find the start of the day, then add 36 hours
+	// (must be more than 24, to account for DST), then find midnight of that
+	// date, and subtract one tick.
+	tomorrow := StartOfDay(t).Add(36 * time.Hour)
+	return StartOfDay(tomorrow).Add(-time.Nanosecond)
+}
+
+// Tomorrow returns the start of the day after t.
+func Tomorrow(t time.Time) time.Time {
+	return StartOfDay(StartOfDay(t).Add(36 * time.Hour))
+}
+
+// StartOfMonth returns the first day of t's month.
+func StartOfMonth(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, t.Location())
+}
+
+// EndOfMonth returns the end of the last day of t's month.
+func EndOfMonth(t time.Time) time.Time {
 	// go to the next month, then a day of 0 removes a day leaving us
 	// at the last day of dates month.
-	return time.Date(date.Year(), date.Month()+1, 0, 0, 0, 0, 0, date.Location())
+	return EndOfDay(time.Date(t.Year(), t.Month()+1, 0, 0, 0, 0, 0, t.Location()))
 }
 
 // FormatAsZulu gets a ISO 8601 formatted date. The date is assumed to be in
@@ -65,4 +89,39 @@ func MonthsTo(a time.Time) int {
 		months = 1
 	}
 	return months
+}
+
+// The below functions are modified from https://github.com/jinzhu/now which
+// is released under the MIT license available here:
+// https://opensource.org/licenses/MIT
+
+// StartOfWeek returns the start of t's week (Monday).
+func StartOfWeek(t time.Time) time.Time {
+	daysToSubtract := t.Weekday() - 1
+	if daysToSubtract == -1 { // Sunday
+		daysToSubtract = 6
+	}
+	return StartOfDay(t).Add(time.Duration(-daysToSubtract) * 24 * time.Hour)
+}
+
+// EndOfWeek returns the end of t's week (Sunday).
+func EndOfWeek(t time.Time) time.Time {
+	if t.Weekday() == time.Sunday {
+		return EndOfDay(t)
+	}
+
+	daysToAdd := 7 - t.Weekday()
+	return EndOfDay(t).Add(time.Duration(daysToAdd) * 24 * time.Hour)
+}
+
+// StartOfQuarter returns the first day of t's quarter.
+func StartOfQuarter(t time.Time) time.Time {
+	month := StartOfMonth(t)
+	offset := (int(month.Month()) - 1) % 3
+	return month.AddDate(0, -offset, 0)
+}
+
+// EndOfQuarter returns the end of the last day of t's quarter.
+func EndOfQuarter(t time.Time) time.Time {
+	return StartOfQuarter(t).AddDate(0, 3, 0).Add(-time.Nanosecond)
 }

--- a/timeutil/timeutil_test.go
+++ b/timeutil/timeutil_test.go
@@ -6,20 +6,156 @@ import (
 	"time"
 )
 
+func TestStartOfDay(t *testing.T) {
+	cases := []struct {
+		in   time.Time
+		want time.Time
+	}{
+		{mustParse(t, "2016-01-01T00:00:00Z"), mustParse(t, "2016-01-01T00:00:00Z")},
+		{mustParse(t, "2016-01-13T00:00:00Z"), mustParse(t, "2016-01-13T00:00:00Z")},
+		{mustParse(t, "2016-01-01T12:34:56Z"), mustParse(t, "2016-01-01T00:00:00Z")},
+		{mustParse(t, "2016-12-30T23:59:59Z"), mustParse(t, "2016-12-30T00:00:00Z")},
+	}
+
+	for _, c := range cases {
+		got := StartOfDay(c.in)
+		if got != c.want {
+			t.Errorf("StartOfDay(%s) =>\n%s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEndOfDay(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/Dublin")
+	if err != nil {
+		t.Fatalf("LoadLocation: Europe/Dublin: %v", err)
+	}
+
+	cases := []struct {
+		in   time.Time
+		want time.Time
+	}{
+		{mustParse(t, "2016-01-01T00:00:00Z"), mustParse(t, "2016-01-01T23:59:59.999999999Z")},
+		{mustParse(t, "2016-01-13T00:00:00Z"), mustParse(t, "2016-01-13T23:59:59.999999999Z")},
+		{mustParse(t, "2016-01-01T12:34:56Z"), mustParse(t, "2016-01-01T23:59:59.999999999Z")},
+		{mustParse(t, "2016-12-30T23:59:59Z"), mustParse(t, "2016-12-30T23:59:59.999999999Z")},
+		{ // dst
+			mustParse(t, "2018-03-25T00:00:00Z").In(loc),
+			mustParse(t, "2018-03-25T23:59:59.999999999+01:00"),
+		},
+	}
+
+	for _, c := range cases {
+		got := EndOfDay(c.in)
+		if got.UTC() != c.want.UTC() {
+			t.Errorf("EndOfDay(%s) =>\n%s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTomorrow(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/Dublin")
+	if err != nil {
+		t.Fatalf("LoadLocation: Europe/Dublin: %v", err)
+	}
+
+	cases := []struct {
+		in   time.Time
+		want time.Time
+	}{
+		{mustParse(t, "2016-01-01T00:00:00Z"), mustParse(t, "2016-01-02T00:00:00Z")},
+		{mustParse(t, "2016-01-13T00:00:00Z"), mustParse(t, "2016-01-14T00:00:00Z")},
+		{mustParse(t, "2016-01-01T12:34:56Z"), mustParse(t, "2016-01-02T00:00:00Z")},
+		{mustParse(t, "2016-12-30T23:59:59Z"), mustParse(t, "2016-12-31T00:00:00Z")},
+		{mustParse(t, "2016-12-31T00:00:00Z"), mustParse(t, "2017-01-01T00:00:00Z")},
+		{ // dst
+			mustParse(t, "2018-03-25T00:00:00Z").In(loc),
+			mustParse(t, "2018-03-26T00:00:00+01:00"),
+		},
+	}
+
+	for _, c := range cases {
+		got := Tomorrow(c.in)
+		if got.UTC() != c.want.UTC() {
+			t.Errorf("Tomorrow(%s) =>\n%s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+func TestStartOfWeek(t *testing.T) {
+	cases := []struct {
+		in   time.Time
+		want time.Time
+	}{
+		{mustParse(t, "2018-01-01T00:00:00Z"), mustParse(t, "2018-01-01T00:00:00Z")},
+		{mustParse(t, "2018-01-02T00:00:00Z"), mustParse(t, "2018-01-01T00:00:00Z")},
+		{mustParse(t, "2018-01-03T00:00:00Z"), mustParse(t, "2018-01-01T00:00:00Z")},
+		{mustParse(t, "2018-01-04T00:00:00Z"), mustParse(t, "2018-01-01T00:00:00Z")},
+		{mustParse(t, "2018-01-05T00:00:00Z"), mustParse(t, "2018-01-01T00:00:00Z")},
+		{mustParse(t, "2018-01-06T00:00:00Z"), mustParse(t, "2018-01-01T00:00:00Z")},
+		{mustParse(t, "2018-01-07T00:00:00Z"), mustParse(t, "2018-01-01T00:00:00Z")},
+
+		{mustParse(t, "2018-01-08T12:34:56Z"), mustParse(t, "2018-01-08T00:00:00Z")},
+		{mustParse(t, "2018-01-09T00:00:00Z"), mustParse(t, "2018-01-08T00:00:00Z")},
+		{mustParse(t, "2018-01-10T00:00:00Z"), mustParse(t, "2018-01-08T00:00:00Z")},
+		{mustParse(t, "2018-01-11T00:00:00Z"), mustParse(t, "2018-01-08T00:00:00Z")},
+		{mustParse(t, "2018-01-12T00:00:00Z"), mustParse(t, "2018-01-08T00:00:00Z")},
+		{mustParse(t, "2018-01-13T00:00:00Z"), mustParse(t, "2018-01-08T00:00:00Z")},
+		{mustParse(t, "2018-01-14T00:00:00Z"), mustParse(t, "2018-01-08T00:00:00Z")},
+	}
+
+	for _, c := range cases {
+		got := StartOfWeek(c.in)
+		if got != c.want {
+			t.Errorf("StartOfWeek(%s) =>\n%s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEndOfWeek(t *testing.T) {
+	cases := []struct {
+		in   time.Time
+		want time.Time
+	}{
+		{mustParse(t, "2018-01-01T00:00:00Z"), mustParse(t, "2018-01-07T23:59:59.999999999Z")},
+		{mustParse(t, "2018-01-02T00:00:00Z"), mustParse(t, "2018-01-07T23:59:59.999999999Z")},
+		{mustParse(t, "2018-01-03T00:00:00Z"), mustParse(t, "2018-01-07T23:59:59.999999999Z")},
+		{mustParse(t, "2018-01-04T00:00:00Z"), mustParse(t, "2018-01-07T23:59:59.999999999Z")},
+		{mustParse(t, "2018-01-05T00:00:00Z"), mustParse(t, "2018-01-07T23:59:59.999999999Z")},
+		{mustParse(t, "2018-01-06T00:00:00Z"), mustParse(t, "2018-01-07T23:59:59.999999999Z")},
+		{mustParse(t, "2018-01-07T00:00:00Z"), mustParse(t, "2018-01-07T23:59:59.999999999Z")},
+
+		{mustParse(t, "2018-01-08T12:34:56Z"), mustParse(t, "2018-01-14T23:59:59.999999999Z")},
+		{mustParse(t, "2018-01-09T00:00:00Z"), mustParse(t, "2018-01-14T23:59:59.999999999Z")},
+		{mustParse(t, "2018-01-10T00:00:00Z"), mustParse(t, "2018-01-14T23:59:59.999999999Z")},
+		{mustParse(t, "2018-01-11T00:00:00Z"), mustParse(t, "2018-01-14T23:59:59.999999999Z")},
+		{mustParse(t, "2018-01-12T00:00:00Z"), mustParse(t, "2018-01-14T23:59:59.999999999Z")},
+		{mustParse(t, "2018-01-13T00:00:00Z"), mustParse(t, "2018-01-14T23:59:59.999999999Z")},
+		{mustParse(t, "2018-01-14T00:00:00Z"), mustParse(t, "2018-01-14T23:59:59.999999999Z")},
+	}
+
+	for _, c := range cases {
+		got := EndOfWeek(c.in)
+		if got != c.want {
+			t.Errorf("EndOfWeek(%s) =>\n%s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
 func TestStartOfMonth(t *testing.T) {
 	cases := []struct {
 		in   time.Time
 		want time.Time
 	}{
-		{mustParse(t, "2016-01-13"), mustParse(t, "2016-01-01")},
-		{mustParse(t, "2016-01-01"), mustParse(t, "2016-01-01")},
-		{mustParse(t, "2016-12-30"), mustParse(t, "2016-12-01")},
+		{mustParse(t, "2016-01-13T00:00:00Z"), mustParse(t, "2016-01-01T00:00:00Z")},
+		{mustParse(t, "2016-01-01T12:34:56Z"), mustParse(t, "2016-01-01T00:00:00Z")},
+		{mustParse(t, "2016-12-30T00:00:00Z"), mustParse(t, "2016-12-01T00:00:00Z")},
 	}
 
 	for _, c := range cases {
 		got := StartOfMonth(c.in)
 		if got != c.want {
-			t.Errorf("StartOfMonth(%s) => %s, want %s", c.in, got, c.want)
+			t.Errorf("StartOfMonth(%s) =>\n%s, want %s", c.in, got, c.want)
 		}
 	}
 }
@@ -29,26 +165,94 @@ func TestEndOfMonth(t *testing.T) {
 		in   time.Time
 		want time.Time
 	}{
-		{mustParse(t, "2016-01-01"), mustParse(t, "2016-01-31")},
-		{mustParse(t, "2016-01-31"), mustParse(t, "2016-01-31")},
-		{mustParse(t, "2016-11-01"), mustParse(t, "2016-11-30")},
-		{mustParse(t, "2016-12-31"), mustParse(t, "2016-12-31")},
+		{mustParse(t, "2016-01-01T00:00:00Z"), mustParse(t, "2016-01-31T23:59:59.999999999Z")},
+		{mustParse(t, "2016-01-31T00:00:00Z"), mustParse(t, "2016-01-31T23:59:59.999999999Z")},
+		{mustParse(t, "2016-11-01T00:00:00Z"), mustParse(t, "2016-11-30T23:59:59.999999999Z")},
+		{mustParse(t, "2016-12-31T00:00:00Z"), mustParse(t, "2016-12-31T23:59:59.999999999Z")},
 		// leap test
-		{mustParse(t, "2012-02-01"), mustParse(t, "2012-02-29")},
-		{mustParse(t, "2013-02-01"), mustParse(t, "2013-02-28")},
+		{mustParse(t, "2012-02-01T00:00:00Z"), mustParse(t, "2012-02-29T23:59:59.999999999Z")},
+		{mustParse(t, "2013-02-01T00:00:00Z"), mustParse(t, "2013-02-28T23:59:59.999999999Z")},
 	}
 
 	for _, c := range cases {
 		got := EndOfMonth(c.in)
 		if got != c.want {
-			t.Errorf("EndOfMonth(%s) => %s, want %s", c.in, got, c.want)
+			t.Errorf("EndOfMonth(%s) =>\n%s, want %s", c.in, got, c.want)
 		}
 	}
 }
 
-// mustParse parses value in the format YYYY-MM-DD failing the test on error.
+func TestStartOfQuarter(t *testing.T) {
+	cases := []struct {
+		in   time.Time
+		want time.Time
+	}{
+		// q1
+		{mustParse(t, "2016-01-01T00:00:00Z"), mustParse(t, "2016-01-01T00:00:00Z")},
+		{mustParse(t, "2016-03-31T23:00:00Z"), mustParse(t, "2016-01-01T00:00:00Z")},
+
+		// q2
+		{mustParse(t, "2016-04-01T00:00:00Z"), mustParse(t, "2016-04-01T00:00:00Z")},
+		{mustParse(t, "2016-06-30T00:00:00Z"), mustParse(t, "2016-04-01T00:00:00Z")},
+
+		// q3
+		{mustParse(t, "2016-07-01T00:00:00Z"), mustParse(t, "2016-07-01T00:00:00Z")},
+		{mustParse(t, "2016-09-30T00:00:00Z"), mustParse(t, "2016-07-01T00:00:00Z")},
+
+		// q4
+		{mustParse(t, "2016-10-01T00:00:00Z"), mustParse(t, "2016-10-01T00:00:00Z")},
+		{mustParse(t, "2016-12-31T00:00:00Z"), mustParse(t, "2016-10-01T00:00:00Z")},
+
+		// leap test
+		{mustParse(t, "2012-02-01T00:00:00Z"), mustParse(t, "2012-01-01T00:00:00Z")},
+		{mustParse(t, "2013-02-01T00:00:00Z"), mustParse(t, "2013-01-01T00:00:00Z")},
+	}
+
+	for _, c := range cases {
+		got := StartOfQuarter(c.in)
+		if got != c.want {
+			t.Errorf("StartOfQuarter(%s) =>\n%s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEndOfQuarter(t *testing.T) {
+	cases := []struct {
+		in   time.Time
+		want time.Time
+	}{
+		// q1
+		{mustParse(t, "2016-01-01T00:00:00Z"), mustParse(t, "2016-03-31T23:59:59.999999999Z")},
+		{mustParse(t, "2016-03-31T00:00:00Z"), mustParse(t, "2016-03-31T23:59:59.999999999Z")},
+
+		// q2
+		{mustParse(t, "2016-04-01T00:00:00Z"), mustParse(t, "2016-06-30T23:59:59.999999999Z")},
+		{mustParse(t, "2016-06-30T00:00:00Z"), mustParse(t, "2016-06-30T23:59:59.999999999Z")},
+
+		// q3
+		{mustParse(t, "2016-07-01T00:00:00Z"), mustParse(t, "2016-09-30T23:59:59.999999999Z")},
+		{mustParse(t, "2016-09-30T00:00:00Z"), mustParse(t, "2016-09-30T23:59:59.999999999Z")},
+
+		// q4
+		{mustParse(t, "2016-10-01T00:00:00Z"), mustParse(t, "2016-12-31T23:59:59.999999999Z")},
+		{mustParse(t, "2016-12-31T00:00:00Z"), mustParse(t, "2016-12-31T23:59:59.999999999Z")},
+
+		// leap test
+		{mustParse(t, "2012-02-01T00:00:00Z"), mustParse(t, "2012-03-31T23:59:59.999999999Z")},
+		{mustParse(t, "2013-02-01T00:00:00Z"), mustParse(t, "2013-03-31T23:59:59.999999999Z")},
+	}
+
+	for _, c := range cases {
+		got := EndOfQuarter(c.in)
+		if got != c.want {
+			t.Errorf("EndOfQuarter(%s) =>\n%s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+// mustParse parses value in the format time.RFC3339Nano failing the test on error.
 func mustParse(t *testing.T, value string) time.Time {
-	const layout = "2006-01-02"
+	const layout = time.RFC3339Nano
 	d, err := time.Parse(layout, value)
 	if err != nil {
 		t.Fatalf("time.Parse(%q, %q) unexpected error: %v", layout, value, err)


### PR DESCRIPTION
Added:
- Tomorrow
- StartOfDay/EndOfDay
- StartOfWeek/EndOfWeek
- StartOfQuarter/EndOfQuarter

Modified:
- EndOfMonth now returns the end of the last day of the month to be consistent
  with the newly added functions


Behaviour of EndOfMonth has changed, not sure if anyone is using this or not. It will now return the end of the day to be consistent with the others so start is 00:00:00 and end of something is 23:59:59...

Some of this logic is adapted from https://github.com/jinzhu/now and the tomorrow logic from desk removing the usage of its time type.