### PR TITLE
Add jsonutil.MustUnmarshal

### DIFF
--- a/jsonutil/jsonutil.go
+++ b/jsonutil/jsonutil.go
@@ -11,3 +11,11 @@ func MustMarshal(v interface{}) []byte {
 	}
 	return b
 }
+
+// MustUnmarshal behaves like json.Unmarshal but will panic on errors.
+func MustUnmarshal(data []byte, v interface{}) {
+	err := json.Unmarshal(data, v)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/jsonutil/jsonutil_test.go
+++ b/jsonutil/jsonutil_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestMustMarshal(t *testing.T) {
@@ -22,4 +23,31 @@ func TestMustMarshal(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMustUnmarshal(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var out struct {
+			Hello string `json:"hello"`
+		}
+		MustUnmarshal([]byte(`{"hello":"world"}`), &out)
+		if out.Hello != "world" {
+			t.Errorf("%#v", out)
+		}
+	})
+
+	t.Run("panic", func(t *testing.T) {
+		defer func() {
+			rec := recover()
+			if rec == nil {
+				t.Errorf("no panic?")
+			}
+		}()
+
+		var out struct {
+			Hello time.Time `json:"hello"`
+		}
+		MustUnmarshal([]byte(`{"hello":"world"}`), &out)
+	})
+
 }


### PR DESCRIPTION
Useful in some tests for example. Before:

    var response announcementResponse
    err := json.Unmarshal(recorder.Body.Bytes(), &response)
    if err != nil {
        t.Error(err)
    }

after:

    var response announcementResponse
    jsonutil.MustUnmarshal(recorder.Body.Bytes(), &response)

In this case it's basically unmarshaling the response in to the struct
it was marshalled from. It should™ never fail.