### PR TITLE
Use full directory name for build.Import

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![codecov](https://codecov.io/gh/Teamwork/utils/branch/master/graph/badge.svg?token=n0k8YjbQOL)](https://codecov.io/gh/Teamwork/utils)
 [![GoDoc](https://godoc.org/github.com/Teamwork/utils?status.svg)](http://teamwork.github.io/utils/)
 
-`utils` is a collection of small and often used extensions to Go's standard
-library that we use in several projects.
+`utils` is a collection of small – and sometimes not so small – extensions to
+Go's standard library. There are no external dependencies.
 
 The naming scheme is `[type]util` or `[pkgname]util`. If there already is a
 `*util` packge in stdlib it's named `utilx` (e.g. `ioutilx`).

--- a/goutil/goutil.go
+++ b/goutil/goutil.go
@@ -56,6 +56,8 @@ func Expand(paths []string, mode build.ImportMode) ([]*build.Package, error) {
 	return out, nil
 }
 
+var cwd string
+
 // ResolvePackage resolves a package path, which can either be a local directory
 // relative to the current dir (e.g. "./example"), a full path (e.g.
 // ~/go/src/example"), or a package path (e.g. "example").
@@ -75,7 +77,13 @@ func ResolvePackage(path string, mode build.ImportMode) (pkg *build.Package, err
 		}
 		pkg, err = build.ImportDir(path, mode)
 	default:
-		pkg, err = build.Import(path, ".", mode)
+		if cwd == "" {
+			cwd, err = os.Getwd()
+			if err != nil {
+				return nil, err
+			}
+		}
+		pkg, err = build.Import(path, cwd, mode)
 	}
 	if err != nil {
 		return nil, err

--- a/goutil/goutil_test.go
+++ b/goutil/goutil_test.go
@@ -151,7 +151,7 @@ func TestParseFiles(t *testing.T) {
 	}
 }
 
-func TestResolveImport(t *testing.T) {
+func TestResolvePackage(t *testing.T) {
 	cases := []struct {
 		inFile, inPkg, want, wantErr string
 	}{
@@ -160,6 +160,9 @@ func TestResolveImport(t *testing.T) {
 		{"package main\nimport \"os\"\n", "os", "os", ""},
 		{"package main\nimport xxx \"net/http\"\n", "xxx", "net/http", ""},
 		{"package main\nimport \"net/http\"\n", "httpx", "", ""},
+
+		// Make sure it works from vendor
+		{"package main\n import \"github.com/teamwork/test\"\n", "test", "github.com/teamwork/test", ""},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Turns out that "." is never resolved, so using it breaks lookups from
the vendor directory.