### PR TITLE
Make stringutil.Left() work for multibyte sequences

### DIFF
--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -17,7 +17,19 @@ func Left(s string, n int) string {
 	if len(s) <= n {
 		return s
 	}
-	return s[:n] + "…"
+
+	var (
+		chari int
+		bytei int
+	)
+	for bytei = range s {
+		if chari >= n {
+			break
+		}
+		chari++
+	}
+
+	return s[:bytei] + "…"
 }
 
 var reUnprintable = regexp.MustCompile("[\x00-\x1F\u200e\u200f]")

--- a/stringutil/stringutil_test.go
+++ b/stringutil/stringutil_test.go
@@ -18,6 +18,8 @@ func TestLeft(t *testing.T) {
 		{"Hello", 4, "Hell…"},
 		{"Hello", 0, "…"},
 		{"Hello", -2, "…"},
+		{"汉语漢語", 1, "汉…"},
+		{"汉语漢語", 3, "汉语漢…"},
 	}
 
 	for i, tc := range cases {
@@ -77,6 +79,13 @@ func TestGetLine(t *testing.T) {
 				t.Errorf("\nout:  %#v\nwant: %#v\n", out, tc.want)
 			}
 		})
+	}
+}
+
+func BenchmarkLeft(b *testing.B) {
+	text := strings.Repeat("Hello, world, it's a sentences!\n", 200)
+	for n := 0; n < b.N; n++ {
+		Left(text, 250)
 	}
 }
 


### PR DESCRIPTION
But slower, but ah well.

before:

    BenchmarkLeft-4                 20000000                79.6 ns/op

now:

    BenchmarkLeft-4                  5000000               344 ns/op