### PR TITLE
Don't add control characters to Content-Disposition header

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ Go's standard library. There are no external dependencies.
 
 The naming scheme is `[type]util` or `[pkgname]util`. If there already is a
 `*util` packge in stdlib it's named `utilx` (e.g. `ioutilx`).
+
+Other useful packages:
+
+- [`github.com/Teamwork/toutf8`](https://github.com/Teamwork/toutf8) – Convert
+  strings to UTF-8.

--- a/httputilx/header/set_test.go
+++ b/httputilx/header/set_test.go
@@ -28,6 +28,10 @@ func TestSetContentDisposition(t *testing.T) {
 			`inline; filename="hello, \"world\".pdf/20"`, ""},
 		{DispositionArgs{Type: TypeInline, Filename: `h€llo.pdf`},
 			`inline; filename="hllo.pdf"; filename*=UTF-8''h%E2%82%ACllo.pdf`, ""},
+		{DispositionArgs{Type: TypeInline, Filename: "h\x10llo.pdf"},
+			`inline; filename="hllo.pdf"`, ""},
+		{DispositionArgs{Type: TypeInline, Filename: "h€\x10llo.pdf"},
+			`inline; filename="hllo.pdf"; filename*=UTF-8''h%E2%82%ACllo.pdf`, ""},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
This will fix: https://sentry.io/teamwork/desk/issues/489287589

The filename is `Surfstitch NZ Google Product \x10Feed.csv`. Note the
`\x10` in there.