### PR TITLE
Some useful functions to retrieve the first and last day of the week

### DIFF
--- a/timeutil/timeutil.go
+++ b/timeutil/timeutil.go
@@ -25,6 +25,24 @@ func EndOfMonth(date time.Time) time.Time {
 	return time.Date(date.Year(), date.Month()+1, 0, 0, 0, 0, 0, date.Location())
 }
 
+// StartOfWeek returns the first day of the week of date. It assumes that Monday
+// is the beginning of the week.
+func StartOfWeek(date time.Time) time.Time {
+	for date.Weekday() != time.Monday {
+		date = date.AddDate(0, 0, -1)
+	}
+	return date
+}
+
+// EndOfWeek returns the last day of the week of date. It assumes that Sunday is
+// the end of the week.
+func EndOfWeek(date time.Time) time.Time {
+	for date.Weekday() != time.Sunday {
+		date = date.AddDate(0, 0, 1)
+	}
+	return date
+}
+
 // FormatAsZulu gets a ISO 8601 formatted date. The date is assumed to be in
 // UTC ("Zulu time").
 //

--- a/timeutil/timeutil_test.go
+++ b/timeutil/timeutil_test.go
@@ -46,6 +46,46 @@ func TestEndOfMonth(t *testing.T) {
 	}
 }
 
+func TestStartOfWeek(t *testing.T) {
+	cases := []struct {
+		in   time.Time
+		want time.Time
+	}{
+		{mustParse(t, "2016-01-13"), mustParse(t, "2016-01-11")},
+		{mustParse(t, "2016-01-01"), mustParse(t, "2015-12-28")},
+		{mustParse(t, "2016-12-30"), mustParse(t, "2016-12-26")},
+	}
+
+	for _, c := range cases {
+		got := StartOfWeek(c.in)
+		if got != c.want {
+			t.Errorf("StartOfWeek(%s) => %s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEndOfWeek(t *testing.T) {
+	cases := []struct {
+		in   time.Time
+		want time.Time
+	}{
+		{mustParse(t, "2016-01-01"), mustParse(t, "2016-01-03")},
+		{mustParse(t, "2016-01-31"), mustParse(t, "2016-01-31")},
+		{mustParse(t, "2016-11-01"), mustParse(t, "2016-11-06")},
+		{mustParse(t, "2016-12-31"), mustParse(t, "2017-01-01")},
+		// leap test
+		{mustParse(t, "2012-02-01"), mustParse(t, "2012-02-05")},
+		{mustParse(t, "2013-02-01"), mustParse(t, "2013-02-03")},
+	}
+
+	for _, c := range cases {
+		got := EndOfWeek(c.in)
+		if got != c.want {
+			t.Errorf("EndOfWeek(%s) => %s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
 // mustParse parses value in the format YYYY-MM-DD failing the test on error.
 func mustParse(t *testing.T, value string) time.Time {
 	const layout = "2006-01-02"


### PR DESCRIPTION
Moving some time util functions from `projectsapigo` ([reference](https://github.com/Teamwork/projectsapigo/blob/1f7ebf21f1686b6d7de599d7392790e8e64af0b1/legacy/util/helpers.go#L46-L58)) to here.