### PR TITLE
Add imageutil.DetectImage

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,14 +27,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c881d21e0d93b374cc68d558b58c9e290e43989bb00db7540f131b53ff2fbfa4"
+  digest = "1:792dd612777789f397b2ed9d5b7d48594c60160a5ccd83e304cb8641e2cf3ea0"
   name = "github.com/teamwork/test"
   packages = [
     ".",
     "diff",
   ]
   pruneopts = ""
-  revision = "dc1dac931dfa18952f340dcf12d5fb0bea92e8c6"
+  revision = "dc090c22ecc80adc5efde11febc63ea1ddfdac0c"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/goutil/goutil_test.go
+++ b/goutil/goutil_test.go
@@ -68,6 +68,7 @@ func TestExpand(t *testing.T) {
 				"github.com/teamwork/utils/goutil",
 				"github.com/teamwork/utils/httputilx",
 				"github.com/teamwork/utils/httputilx/header",
+				"github.com/teamwork/utils/imageutil",
 				"github.com/teamwork/utils/ioutilx",
 				"github.com/teamwork/utils/jsonutil",
 				"github.com/teamwork/utils/maputil",

--- a/imageutil/doc.go
+++ b/imageutil/doc.go
@@ -1,0 +1,2 @@
+// Package imageutil adds functions for working with images.
+package imageutil // import "github.com/teamwork/utils/imageutil"

--- a/imageutil/sniff.go
+++ b/imageutil/sniff.go
@@ -1,0 +1,97 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package imageutil
+
+import (
+	"bytes"
+)
+
+// The algorithm uses at most sniffLen bytes to make its decision.
+const sniffLen = 14
+
+// DetectImage detects the image type of the data.
+//
+// It's a copy of http.DetectContentType with some unnecessary parts removed,
+// making it about 10 times faster.
+//
+// It returns an empty string if the image type can't be determined.
+func DetectImage(data []byte) string {
+	if len(data) > sniffLen {
+		data = data[:sniffLen]
+	}
+
+	// Index of the first non-whitespace byte in data.
+	firstNonWS := 0
+	//for ; firstNonWS < len(data) && isWS(data[firstNonWS]); firstNonWS++ {
+	//}
+
+	for _, sig := range sniffSignatures {
+		if ct := sig.match(data, firstNonWS); ct != "" {
+			return ct
+		}
+	}
+
+	return ""
+}
+
+type sniffSig interface {
+	// match returns the MIME type of the data, or "" if unknown.
+	match(data []byte, firstNonWS int) string
+}
+
+// Data matching the table in section 6.
+var sniffSignatures = []sniffSig{
+	&exactSig{[]byte("GIF87a"), "image/gif"},
+	&exactSig{[]byte("GIF89a"), "image/gif"},
+	&exactSig{[]byte("\x89\x50\x4E\x47\x0D\x0A\x1A\x0A"), "image/png"},
+	&exactSig{[]byte("\xFF\xD8\xFF"), "image/jpeg"},
+	&exactSig{[]byte("BM"), "image/bmp"},
+	&exactSig{[]byte("\x00\x00\x01\x00"), "image/vnd.microsoft.icon"},
+	&maskedSig{
+		mask: []byte("\xFF\xFF\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF\xFF\xFF\xFF"),
+		pat:  []byte("RIFF\x00\x00\x00\x00WEBPVP"),
+		ct:   "image/webp",
+	},
+}
+
+type exactSig struct {
+	sig []byte
+	ct  string
+}
+
+func (e *exactSig) match(data []byte, firstNonWS int) string {
+	if bytes.HasPrefix(data, e.sig) {
+		return e.ct
+	}
+	return ""
+}
+
+type maskedSig struct {
+	mask, pat []byte
+	//skipWS    bool
+	ct string
+}
+
+func (m *maskedSig) match(data []byte, firstNonWS int) string {
+	// pattern matching algorithm section 6
+	// https://mimesniff.spec.whatwg.org/#pattern-matching-algorithm
+
+	//if m.skipWS {
+	//	data = data[firstNonWS:]
+	//}
+	if len(m.pat) != len(m.mask) {
+		return ""
+	}
+	if len(data) < len(m.mask) {
+		return ""
+	}
+	for i, mask := range m.mask {
+		db := data[i] & mask
+		if db != m.pat[i] {
+			return ""
+		}
+	}
+	return m.ct
+}

--- a/imageutil/sniff_test.go
+++ b/imageutil/sniff_test.go
@@ -1,0 +1,32 @@
+package imageutil
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/teamwork/test/image"
+)
+
+func TestDetectContentType(t *testing.T) {
+	if ct := DetectImage(image.GIF); ct != "image/gif" {
+		t.Error(ct)
+	}
+	if ct := DetectImage(image.JPEG); ct != "image/jpeg" {
+		t.Error(ct)
+	}
+	if ct := DetectImage(image.PNG); ct != "image/png" {
+		t.Error(ct)
+	}
+}
+
+func BenchmarkDetect(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		DetectImage(image.PNG)
+	}
+}
+
+func BenchmarkHTTPDetect(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		http.DetectContentType(image.PNG)
+	}
+}


### PR DESCRIPTION
Copy of http.DetectContentType with non-image parts removed, making it
about 10 times faster.

Do we really need this performance? Guess not, as the original isn't
that slow; but it won't hurt either.