### PR TITLE
Add errorutil.FilterTrace

### DIFF
--- a/errorutil/errorutil.go
+++ b/errorutil/errorutil.go
@@ -1,0 +1,156 @@
+// Package errorutil provides functions to work with errors.
+package errorutil // import "github.com/teamwork/utils/errorutil"
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Modes for FilterPatterns.
+const (
+	FilterTraceExlude  = 0 // Exclude the paths that match.
+	FilterTraceInclude = 1 // Include only the paths that match.
+)
+
+// Patterns for filtering error traces.
+type Patterns struct {
+	ret     bool
+	files   []string
+	pkgs    []string
+	matches []string
+	regexps []*regexp.Regexp
+}
+
+// FilterPattern compiles filter patterns for FilterTrace()
+//
+// Frames are filtered according to the mode; with FilterTraceExlude all frames
+// are included except those that match the given patterns. With
+// FilterTraceInclude all frames are excluded except those that match one of the
+// patterns.
+//
+// Paths starting with re: are treated as a regular expression.
+//
+// Paths starting with match: are matched with filepath.Match()
+//
+// Paths ending with .go are matches against the full file path (i.e.
+// /home/martin/go/src/.../file.go).
+//
+// Anything else is matches against the package path (i.e. github.com/foo/bar).
+func FilterPattern(mode int, paths ...string) Patterns {
+	var pat Patterns
+	switch mode {
+	case FilterTraceExlude:
+		pat.ret = true
+	case FilterTraceInclude:
+		pat.ret = false
+	default:
+		panic(fmt.Sprintf("FilterPattern: invalid mode: %q", mode))
+	}
+
+	for _, p := range paths {
+		switch {
+		case strings.HasPrefix(p, "match:"):
+			// Make sure pattern isn't malformed.
+			_, err := filepath.Match(p, "")
+			if err != nil {
+				panic(fmt.Sprintf("FilterPattern: invalid match pattern: %s", err))
+			}
+
+			pat.matches = append(pat.matches, p[6:])
+		case strings.HasPrefix(p, "re:"):
+			pat.regexps = append(pat.regexps, regexp.MustCompile(p[3:]))
+		case strings.HasSuffix(p, ".go"):
+			pat.files = append(pat.files, p)
+		default:
+			pat.pkgs = append(pat.pkgs, p)
+		}
+	}
+
+	return pat
+}
+
+// Match a file path.
+func (p Patterns) Match(pc uintptr) bool {
+	fn := runtime.FuncForPC(pc)
+	file, _ := fn.FileLine(pc)
+
+	for _, f := range p.files {
+		if file == f {
+			return p.ret
+		}
+	}
+	for _, d := range p.pkgs {
+		pkg := fn.Name()
+		if i := strings.LastIndex(pkg, "."); i > -1 {
+			pkg = pkg[:i]
+		}
+		if pkg == d {
+			return p.ret
+		}
+	}
+	for _, m := range p.matches {
+		if ok, err := filepath.Match(m, file); ok && err == nil {
+			return p.ret
+		}
+	}
+	for _, r := range p.regexps {
+		if r.MatchString(file) {
+			return p.ret
+		}
+	}
+
+	return !p.ret
+}
+
+// FilterTrace removes unneeded stack traces from an error.
+func FilterTrace(err error, p Patterns) error {
+	tErr, ok := err.(stackTracer)
+	if !ok {
+		return err
+	}
+
+	var frames errors.StackTrace
+	for _, frame := range tErr.StackTrace() {
+		if !p.Match(uintptr(frame) - 1) {
+			frames = append(frames, frame)
+		}
+	}
+
+	// Keep original stack if we filtered everything, because that's not likely
+	// going to be useful.
+	if len(frames) == 0 {
+		_, _ = fmt.Fprintf(os.Stderr,
+			"WARNING: errorutil.FilterTrace: all stack frames filtered; keeping full trace\n")
+		frames = tErr.StackTrace()
+	}
+
+	return &withStack{
+		err:   err,
+		stack: frames,
+	}
+}
+
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+type withStack struct {
+	err   error
+	stack errors.StackTrace
+}
+
+func (w *withStack) Cause() error                  { return w.err }
+func (w *withStack) StackTrace() errors.StackTrace { return w.stack }
+
+func (w *withStack) Error() string {
+	if w.err == nil {
+		return ""
+	}
+	return w.err.Error()
+}

--- a/errorutil/errorutil_test.go
+++ b/errorutil/errorutil_test.go
@@ -1,0 +1,67 @@
+package errorutil
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestFilterExclude(t *testing.T) {
+	err := makeErr()
+	err = errors.Wrap(err, "w00t")
+	err = errors.Wrap(err, "context")
+	err = FilterTrace(err, FilterPattern(FilterTraceExlude,
+		"testing",
+		"re:.*github.com/teamwork/utils/.*",
+	))
+
+	tErr, _ := err.(stackTracer)
+	if len(tErr.StackTrace()) != 1 {
+		t.Errorf("wrong length for stack trace: %d; wanted 1", len(tErr.StackTrace()))
+		for _, f := range tErr.StackTrace() {
+			t.Logf("%+v\n", f)
+		}
+	}
+}
+
+func TestFilterExcludeAll(t *testing.T) {
+	err := makeErr()
+	err = errors.Wrap(err, "w00t")
+	err = errors.Wrap(err, "context")
+	err = FilterTrace(err, FilterPattern(FilterTraceExlude, "re:.*"))
+
+	tErr, _ := err.(stackTracer)
+	if len(tErr.StackTrace()) != 3 {
+		t.Errorf("wrong length for stack trace: %d; wanted 3", len(tErr.StackTrace()))
+		for _, f := range tErr.StackTrace() {
+			t.Logf("%+v\n", f)
+		}
+	}
+}
+
+func TestFilterInclude(t *testing.T) {
+	err := makeErr()
+	err = errors.Wrap(err, "w00t")
+	err = errors.Wrap(err, "context")
+	err = FilterTrace(err, FilterPattern(FilterTraceInclude,
+		"re:.*github.com/teamwork/utils/.*"))
+
+	tErr, _ := err.(stackTracer)
+	if len(tErr.StackTrace()) != 1 {
+		t.Errorf("wrong length for stack trace: %d; wanted 1", len(tErr.StackTrace()))
+		for _, f := range tErr.StackTrace() {
+			t.Logf("%+v\n", f)
+		}
+	}
+}
+
+func makeErr() error {
+	err := zxc()
+	return errors.WithStack(err)
+}
+
+func zxc() error {
+	_, err := ioutil.ReadFile("/var/empty/nonexistent")
+	return errors.Wrap(err, "could not read")
+}

--- a/goutil/goutil_test.go
+++ b/goutil/goutil_test.go
@@ -65,6 +65,7 @@ func TestExpand(t *testing.T) {
 			[]string{
 				"github.com/teamwork/utils",
 				"github.com/teamwork/utils/aesutil",
+				"github.com/teamwork/utils/errorutil",
 				"github.com/teamwork/utils/goutil",
 				"github.com/teamwork/utils/httputilx",
 				"github.com/teamwork/utils/httputilx/header",


### PR DESCRIPTION
This is something I've been annoyed about for quite some time: the
length of our stack traces. They're very long, and I constantly need to
scroll my terminal to see the error and/or any context before it (as
they're too large to fit on my window, even at full screen). It's pretty
annoying.

For example, returning an error from the `mysql` repo in Hub returns 32
stack frames right now, of which only four are useful:

    github.com/teamwork/hub/mysql.(*InstallationRepository).Get
            /home/martin/work/src/github.com/teamwork/hub/mysql/installation.go:28
    github.com/teamwork/hub.(*InstallationService).Get
            /home/martin/work/src/github.com/teamwork/hub/installation.go:29
    github.com/teamwork/hub/api.Installations.get
            /home/martin/work/src/github.com/teamwork/hub/api/installations.go:58
    github.com/teamwork/hub/api.Installations.get-fm
            /home/martin/work/src/github.com/teamwork/hub/api/installations.go:35

This is an issue both in our echo error handler and panic recoverer.

With this function we can do some filtering; I already did an ad-hoc
experiment in Hub here: https://github.com/Teamwork/hub/compare/trace
and that seems to work well.

I think that for most apps we can just filter everything except the app
package; e.g. `re:github.com/teamwork/hub/.*`, instead of writing an
extensive blacklist. Either way, this will allow us to do either.

The biggest potential issue is what might happen if a panic occurs
somewhere outside the app; I think that in most cases the entire trace
should get filtered, meaning everything will get shown. If not, I can
see about handling that in the `log` package.