### PR TITLE
Add dbg package

### DIFF
--- a/dbg/dbg.go
+++ b/dbg/dbg.go
@@ -1,0 +1,29 @@
+// Package dbg contains helper functions useful when debugging programs.
+package dbg // import "github.com/teamwork/utils/dbg"
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Loc gets a location in the stack trace.
+//
+// Use 0 for the current location; 1 for one up, etc.
+func Loc(n int) string {
+	_, file, line, ok := runtime.Caller(n + 1)
+	if !ok {
+		file = "???"
+		line = 0
+	}
+
+	short := file
+	for i := len(file) - 1; i > 0; i-- {
+		if file[i] == '/' {
+			short = file[i+1:]
+			break
+		}
+	}
+	file = short
+
+	return fmt.Sprintf("%v:%v", file, line)
+}

--- a/goutil/goutil_test.go
+++ b/goutil/goutil_test.go
@@ -65,6 +65,7 @@ func TestExpand(t *testing.T) {
 			[]string{
 				"github.com/teamwork/utils",
 				"github.com/teamwork/utils/aesutil",
+				"github.com/teamwork/utils/dbg",
 				"github.com/teamwork/utils/errorutil",
 				"github.com/teamwork/utils/goutil",
 				"github.com/teamwork/utils/httputilx",


### PR DESCRIPTION
Often written ad-hoc version of this; sometimes when debugging code you
print out data:

	fmt.Println("Append", tbl)

But not always clear where that's being called from; so we can now use:

	fmt.Println("Append", tbl, dbg.Loc(1))

And get:

    Append hub_installations_apps installation.go:492
    Append hub_installations_apps installation.go:36

Which is useful :-)

I kep the package and function name short so it's quick to type.

Pedro: "it's 2019 and use a debugger!" Sorry, I'm not very hip :-(