### PR TITLE
jsonutil: add MustMarshalIndent(), Indent(), MustIndent()

### DIFF
--- a/jsonutil/jsonutil.go
+++ b/jsonutil/jsonutil.go
@@ -12,10 +12,43 @@ func MustMarshal(v interface{}) []byte {
 	return b
 }
 
+// MustMarshalIndent behaves like json.MarshalIndent but will panic on errors.
+func MustMarshalIndent(v interface{}, prefix, indent string) []byte {
+	b, err := json.MarshalIndent(v, prefix, indent)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
 // MustUnmarshal behaves like json.Unmarshal but will panic on errors.
 func MustUnmarshal(data []byte, v interface{}) {
 	err := json.Unmarshal(data, v)
 	if err != nil {
 		panic(err)
 	}
+}
+
+// Indent a json string by unmarshalling it and marshalling it with
+// MarshalIndent.
+//
+// The data will be unmarshalled in to v, which must be a pointer. Example:
+//
+//   Indent(`{"a": "b"}`, &map[string]string{}, "", "  ")
+func Indent(data []byte, v interface{}, prefix, indent string) ([]byte, error) {
+	err := json.Unmarshal(data, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.MarshalIndent(v, prefix, indent)
+}
+
+// MustIndent behaves like Indent but will panic on errors.
+func MustIndent(data []byte, v interface{}, prefix, indent string) []byte {
+	b, err := Indent(data, v, prefix, indent)
+	if err != nil {
+		panic(err)
+	}
+	return b
 }

--- a/jsonutil/jsonutil_test.go
+++ b/jsonutil/jsonutil_test.go
@@ -19,7 +19,43 @@ func TestMustMarshal(t *testing.T) {
 		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
 			out := MustMarshal(tc.in)
 			if !reflect.DeepEqual(out, tc.want) {
-				t.Errorf("\nout:  %#v\nwant: %#v\n", out, tc.want)
+				t.Errorf("\nout:  %s\nwant: %s\n", out, tc.want)
+			}
+		})
+	}
+}
+
+func TestMustMarshalIndent(t *testing.T) {
+	cases := []struct {
+		in   map[string]string
+		want []byte
+	}{
+		{map[string]string{"hello": "world", "a": "b"}, []byte("{\n  \"a\": \"b\",\n  \"hello\": \"world\"\n}")},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			out := MustMarshalIndent(tc.in, "", "  ")
+			if !reflect.DeepEqual(out, tc.want) {
+				t.Errorf("\nout:  %s\nwant: %s\n", out, tc.want)
+			}
+		})
+	}
+}
+
+func TestMustFormat(t *testing.T) {
+	cases := []struct {
+		in   []byte
+		want []byte
+	}{
+		{[]byte(`{"hello": "world", "a": "b"}`), []byte("{\n  \"a\": \"b\",\n  \"hello\": \"world\"\n}")},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			out := MustIndent(tc.in, &map[string]string{}, "", "  ")
+			if !reflect.DeepEqual(out, tc.want) {
+				t.Errorf("\nout:  %s\nwant: %s\n", out, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
The Format() function is useful especially in tests, where you want to
compare two JSON strings but they're both without newlines. The diffs
that e.g. go-cmp generate are useless, since they just show that that
one line changed.