### PR TITLE
Correct typo: Exlude

### DIFF
--- a/errorutil/errorutil.go
+++ b/errorutil/errorutil.go
@@ -14,7 +14,7 @@ import (
 
 // Modes for FilterPatterns.
 const (
-	FilterTraceExlude  = 0 // Exclude the paths that match.
+	FilterTraceExclude = 0 // Exclude the paths that match.
 	FilterTraceInclude = 1 // Include only the paths that match.
 )
 
@@ -29,7 +29,7 @@ type Patterns struct {
 
 // FilterPattern compiles filter patterns for FilterTrace()
 //
-// Frames are filtered according to the mode; with FilterTraceExlude all frames
+// Frames are filtered according to the mode; with FilterTraceExclude all frames
 // are included except those that match the given patterns. With
 // FilterTraceInclude all frames are excluded except those that match one of the
 // patterns.
@@ -45,7 +45,7 @@ type Patterns struct {
 func FilterPattern(mode int, paths ...string) *Patterns {
 	var pat Patterns
 	switch mode {
-	case FilterTraceExlude:
+	case FilterTraceExclude:
 		pat.ret = true
 	case FilterTraceInclude:
 		pat.ret = false

--- a/errorutil/errorutil_test.go
+++ b/errorutil/errorutil_test.go
@@ -11,7 +11,7 @@ func TestFilterExclude(t *testing.T) {
 	err := makeErr()
 	err = errors.Wrap(err, "w00t")
 	err = errors.Wrap(err, "context")
-	err = FilterTrace(err, FilterPattern(FilterTraceExlude,
+	err = FilterTrace(err, FilterPattern(FilterTraceExclude,
 		"testing",
 		"re:.*github.com/teamwork/utils/.*",
 	))
@@ -29,7 +29,7 @@ func TestFilterExcludeAll(t *testing.T) {
 	err := makeErr()
 	err = errors.Wrap(err, "w00t")
 	err = errors.Wrap(err, "context")
-	err = FilterTrace(err, FilterPattern(FilterTraceExlude, "re:.*"))
+	err = FilterTrace(err, FilterPattern(FilterTraceExclude, "re:.*"))
 
 	tErr, _ := err.(stackTracer)
 	if len(tErr.StackTrace()) != 3 {
@@ -58,7 +58,7 @@ func TestFilterInclude(t *testing.T) {
 
 func TestFilterNil(t *testing.T) {
 	var err error
-	err = FilterTrace(err, FilterPattern(FilterTraceExlude, "testing"))
+	err = FilterTrace(err, FilterPattern(FilterTraceExclude, "testing"))
 	if err != nil {
 		t.Errorf("wrong error: %v", err)
 	}


### PR DESCRIPTION
I managed to mistype `Exclude` as `Exlude` in all instances of
`FilterTraceExlude` 🤦 Probably some sort of search/replace mishap.