### PR TITLE
stringutil: fix Left for multibyte characters

### DIFF
--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -14,6 +14,8 @@ func Left(s string, n int) string {
 	if n < 0 {
 		n = 0
 	}
+
+	// Quick check for non-multibyte strings.
 	if len(s) <= n {
 		return s
 	}
@@ -23,13 +25,14 @@ func Left(s string, n int) string {
 		bytei int
 	)
 	for bytei = range s {
-		if chari >= n {
-			break
-		}
 		chari++
+
+		if chari > n {
+			return s[:bytei] + "…"
+		}
 	}
 
-	return s[:bytei] + "…"
+	return s
 }
 
 // UpperFirst transforms the first character to upper case, leaving the rest of

--- a/stringutil/stringutil_test.go
+++ b/stringutil/stringutil_test.go
@@ -20,6 +20,7 @@ func TestLeft(t *testing.T) {
 		{"Hello", -2, "…"},
 		{"汉语漢語", 1, "汉…"},
 		{"汉语漢語", 3, "汉语漢…"},
+		{"汉语漢語", 4, "汉语漢語"},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
This PR fixes `Left` to support multibyte characters. If you iterate over a string with for each loop, you actually iterate over the corresponding byte array, so you will not be able to count the string chars. If you want to get the chars from given string it's enough to cast the string to slice of runes ([]rune).