### PR TITLE
Add SetCSP() helper function to set CSP headers

### DIFF
--- a/httputilx/header/example_test.go
+++ b/httputilx/header/example_test.go
@@ -1,0 +1,31 @@
+package header_test
+
+import (
+	"net/http"
+
+	"github.com/teamwork/utils/httputilx/header"
+)
+
+func ExampleSetCSP() {
+	static := "static.example.com"
+	headers := make(http.Header)
+	header.SetCSP(headers, header.CSPArgs{
+		header.CSPDefaultSrc: {header.CSPSourceNone},
+		header.CSPScriptSrc:  {static},
+		header.CSPStyleSrc:   {static, header.CSPSourceUnsafeInline},
+		header.CSPFormAction: {header.CSPSourceSelf},
+		header.CSPReportURI:  {"/csp"},
+	})
+
+	// Output:
+}
+
+func ExampleSetContentDisposition() {
+	headers := make(http.Header)
+	header.SetContentDisposition(headers, header.DispositionArgs{
+		Type:     "image/png",
+		Filename: "foo.png",
+	})
+
+	// Output:
+}

--- a/httputilx/header/set.go
+++ b/httputilx/header/set.go
@@ -96,3 +96,93 @@ func formatFilename(s string) (string, string, bool) {
 
 	return strings.TrimRight(string(uni), "\x00"), strings.TrimRight(string(ascii), "\x00"), has
 }
+
+// CSP Directives.
+const (
+	// Fetch directives
+	CSPChildSrc    = "child-src"    // Web workers and nested contexts such as frames
+	CSPConnectSrc  = "connect-src"  // Script interfaces: Ajax, WebSocket, Fetch API, etc
+	CSPDefaultSrc  = "default-src"  // Fallback for the other directives
+	CSPFontSrc     = "font-src"     // Custom fonts
+	CSPFrameSrc    = "frame-src"    // <frame> and <iframe>
+	CSPImgSrc      = "img-src"      // Images (HTML and CSS), favicon
+	CSPManifestSrc = "manifest-src" // Web app manifest
+	CSPMediaSrc    = "media-src"    // <audio> and <video>
+	CSPObjectSrc   = "object-src"   // <object>, <embed>, and <applet>
+	CSPScriptSrc   = "script-src"   // JavaScript
+	CSPStyleSrc    = "style-src"    // CSS
+
+	// Document directives govern the properties of a document
+	CSPBaseURI     = "base-uri"     // Restrict what can be used in <base>
+	CSPPluginTypes = "plugin-types" // Whitelist MIME types for <object>, <embed>, <applet>
+	CSPSandbox     = "sandbox"      // Enable sandbox for the page
+
+	// Navigation directives govern whereto a user can navigate
+	CSPFormAction     = "form-action"     // Restrict targets for form submissions
+	CSPFrameAncestors = "frame-ancestors" // Valid parents for embedding with frames, <object>, etc.
+
+	// Reporting directives control the reporting process of CSP violations; see
+	// also the Content-Security-Policy-Report-Only header
+	CSPReportURI = "report-uri"
+
+	// Other directives
+	CSPBlockAllMixedContent = "block-all-mixed-content" // Don't load any HTTP content when using https
+)
+
+// Content-Security-Policy values
+const (
+	CSPSourceSelf         = "'self'"          // Exact origin of the document
+	CSPSourceNone         = "'none'"          // Nothing matches
+	CSPSourceUnsafeInline = "'unsafe-inline'" // Inline <script>/<style>, onevent="", etc.
+	CSPSourceUnsaleEval   = "'unsafe-eval'"   // eval()
+	CSPSourceStar         = "*"               // Everything
+)
+
+// CSPArgs are arguments for SetCSP().
+type CSPArgs map[string][]string
+
+// SetCSP sets a Content-Security-Policy header.
+//
+// Most directives require a value. The exceptions are CSPSandbox and
+// CSPBlockAllMixedContent.
+//
+// Only special values (CSPSource* constants) need to be quoted. Don't add
+// quotes around hosts.
+//
+// Valid sources:
+//
+//   CSPSource*
+//   Hosts               example.com, *.example.com, https://example.com
+//   Schema              data:, blob:, etc.
+//   nonce-<val>         inline scripts using a cryptographic nonce
+//   <hash_algo>-<val>   hash of specific script.
+//
+// Also see: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP and
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+func SetCSP(header http.Header, args CSPArgs) error {
+	if header == nil {
+		return errors.New("header is nil map")
+	}
+
+	var b strings.Builder
+	i := 1
+	for k, v := range args {
+		b.WriteString(k)
+		b.WriteString(" ")
+
+		for j := range v {
+			b.WriteString(v[j])
+			if j != len(v)-1 {
+				b.WriteString(" ")
+			}
+		}
+
+		if i != len(args) {
+			b.WriteString("; ")
+		}
+		i++
+	}
+
+	header["Content-Security-Policy"] = []string{b.String()}
+	return nil
+}

--- a/httputilx/header/set_test.go
+++ b/httputilx/header/set_test.go
@@ -49,3 +49,42 @@ func TestSetContentDisposition(t *testing.T) {
 		})
 	}
 }
+
+func TestCSP(t *testing.T) {
+	tests := []struct {
+		in   CSPArgs
+		want string
+	}{
+		{CSPArgs{}, ""},
+		{
+			CSPArgs{CSPDefaultSrc: {CSPSourceSelf}},
+			"default-src 'self'",
+		},
+		{
+			CSPArgs{CSPDefaultSrc: {CSPSourceSelf, "https://example.com"}},
+			"default-src 'self' https://example.com",
+		},
+		{
+			CSPArgs{
+				CSPDefaultSrc: {CSPSourceSelf, "https://example.com"},
+				CSPConnectSrc: {"https://a.com", "https://b.com"},
+			},
+			"default-src 'self' https://example.com; connect-src https://a.com https://b.com",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			header := make(http.Header)
+			err := SetCSP(header, tt.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			out := header["Content-Security-Policy"][0]
+			if out != tt.want {
+				t.Errorf("\nout:  %#v\nwant: %#v\n", out, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding Content-Security-Policy headers is a bit of a pain and ugly. Example:

    headers["Content-Security-Policy"] = {fmt.Sprintf(
        "default-src 'none'; img-src %[1]s; script-src %[1]s; style-src %[1]s 'unsafe-inline';"+
            "font-src %[1]s; form-action 'self'; connect-src 'self'; report-uri /csp",
            cfg.DomainStatic)}

With this helper it becomes:

    header.SetCSP(headers, header.CSPArgs{
        header.CSPDefaultSrc: {header.CSPSourceNone},
        header.CSPImgSrc:     {cfg.DomainStatic},
        header.CSPScriptSrc:  {cfg.DomainStatic},
        header.CSPStyleSrc:   {cfg.DomainStatic, header.CSPSourceUnsafeInline},
        header.CSPFontSrc:    {cfg.DomainStatic},
        header.CSPFormAction: {header.CSPSourceSelf},
        header.CSPConnectSrc: {header.CSPSourceSelf},
        header.CSPReportURI:  {"/csp"},
    })