### PR TITLE
Add ability to return MB instead of MiB format

### DIFF
--- a/mathutil/mathutil.go
+++ b/mathutil/mathutil.go
@@ -62,14 +62,18 @@ type Byte float64
 var units = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB"}
 var unitsAsBytes = []string{"B", "KB", "MB", "GB", "TB", "PB"}
 
+// String will return the bytes formatted as "mebibytes" (multiples of 1024)
 func (b Byte) String() string {
 	return b.HumanReadable(1024, units)
 }
 
+// StringAsBytes will return the bytes formatted as "bytes" (multiples of 1000)
 func (b Byte) StringAsBytes() string {
 	return b.HumanReadable(1000, unitsAsBytes)
 }
 
+// HumanReadable will take a measurement multiple as well as a slice of formats
+// to convert the byte into a human readable format using the given parameters.
 func (b Byte) HumanReadable(measurement Byte, format []string) string {
 	i := 0
 	for ; i < len(units); i++ {

--- a/mathutil/mathutil.go
+++ b/mathutil/mathutil.go
@@ -60,14 +60,23 @@ func IsSignedZero(f float64) bool {
 type Byte float64
 
 var units = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB"}
+var unitsAsBytes = []string{"B", "KB", "MB", "GB", "TB", "PB"}
 
 func (b Byte) String() string {
+	return b.HumanReadable(1024, units)
+}
+
+func (b Byte) StringAsBytes() string {
+	return b.HumanReadable(1000, unitsAsBytes)
+}
+
+func (b Byte) HumanReadable(measurement Byte, format []string) string {
 	i := 0
 	for ; i < len(units); i++ {
-		if b < 1024 {
-			return fmt.Sprintf("%.1f%s", b, units[i])
+		if b < measurement {
+			return fmt.Sprintf("%.1f%s", b, format[i])
 		}
-		b /= 1024
+		b /= measurement
 	}
-	return fmt.Sprintf("%.1f%s", b*1024, units[i-1])
+	return fmt.Sprintf("%.1f%s", b*measurement, format[i-1])
 }

--- a/mathutil/mathutil_test.go
+++ b/mathutil/mathutil_test.go
@@ -74,7 +74,7 @@ func TestIsSignedZero(t *testing.T) {
 	}
 }
 
-func TestByte(t *testing.T) {
+func TestMebi(t *testing.T) {
 	cases := []struct {
 		in   float64
 		want string
@@ -92,6 +92,31 @@ func TestByte(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%v", tc.in), func(t *testing.T) {
 			out := Byte(tc.in).String()
+			if out != tc.want {
+				t.Errorf("\nout:  %#v\nwant: %#v\n", out, tc.want)
+			}
+		})
+	}
+}
+
+func TestByte(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{500, "500.0B"},
+		{1023, "1.0KB"},
+		{1000, "1.0KB"},
+		{1424, "1.4KB"},
+		{152310, "152.3KB"},
+		{1024 * 1190, "1.2MB"},
+		{(math.Pow(1024, 5) * 3) + (math.Pow(1024, 4) * 400), "3.8PB"},
+		{(math.Pow(1024, 6) * 3) + (math.Pow(1024, 5) * 400), "3909.1PB"},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%v", tc.in), func(t *testing.T) {
+			out := Byte(tc.in).StringAsBytes()
 			if out != tc.want {
 				t.Errorf("\nout:  %#v\nwant: %#v\n", out, tc.want)
 			}


### PR DESCRIPTION
Not many people actually use mebi's instead of bytes, so I've added support for bytes here, which is what more people are used to working with, while keeping backwards compatability.