### PR TITLE
Add sliceutil.Intersection function

### DIFF
--- a/sliceutil/sets.go
+++ b/sliceutil/sets.go
@@ -45,7 +45,7 @@ func Complement(a, b []int64) (aOnly, bOnly []int64) {
 // Intersection returns the elements common to both a and b
 func Intersection(a, b []int64) []int64 {
 	inter := []int64{}
-	hash := make(map[int64]bool)
+	hash := make(map[int64]bool, len(a))
 	for _, i := range a {
 		hash[i] = false
 	}

--- a/sliceutil/sets.go
+++ b/sliceutil/sets.go
@@ -41,3 +41,18 @@ func Complement(a, b []int64) (aOnly, bOnly []int64) {
 
 	return aOnly, bOnly
 }
+
+// Intersection returns the elements common to both a and b
+func Intersection(a, b []int64) (inter []int64) {
+	hash := make(map[int64]bool)
+	for _, i := range a {
+		hash[i] = false
+	}
+	for _, i := range b {
+		if done, exists := hash[i]; exists && !done {
+			inter = append(inter, i)
+			hash[i] = true
+		}
+	}
+	return inter
+}

--- a/sliceutil/sets.go
+++ b/sliceutil/sets.go
@@ -43,7 +43,8 @@ func Complement(a, b []int64) (aOnly, bOnly []int64) {
 }
 
 // Intersection returns the elements common to both a and b
-func Intersection(a, b []int64) (inter []int64) {
+func Intersection(a, b []int64) []int64 {
+	inter := []int64{}
 	hash := make(map[int64]bool)
 	for _, i := range a {
 		hash[i] = false

--- a/sliceutil/sets_test.go
+++ b/sliceutil/sets_test.go
@@ -97,6 +97,64 @@ func TestComplement(t *testing.T) {
 	}
 }
 
+func TestIntersection(t *testing.T) {
+	type ciTest struct {
+		name   string
+		a      []int64
+		b      []int64
+		result []int64
+	}
+	tests := []ciTest{
+		{
+			name:   "EmptyLists",
+			result: []int64{},
+		},
+		{
+			name:   "AOnly",
+			a:      []int64{1, 2, 3},
+			result: []int64{},
+		},
+		{
+			name:   "BOnly",
+			b:      []int64{1, 2, 3},
+			result: []int64{},
+		},
+		{
+			name:   "Equal",
+			a:      []int64{1, 2, 3},
+			b:      []int64{1, 2, 3},
+			result: []int64{1, 2, 3},
+		},
+		{
+			name:   "Disjoint",
+			a:      []int64{1, 2, 3},
+			b:      []int64{5, 6, 7},
+			result: []int64{},
+		},
+		{
+			name:   "Overlap",
+			a:      []int64{1, 2, 3, 4},
+			b:      []int64{3, 4, 5, 6},
+			result: []int64{3, 4},
+		},
+		{
+			name:   "Overlap with repeated values",
+			a:      []int64{6, 4, 5, 3, 6},
+			b:      []int64{2, 1, 4, 3, 1},
+			result: []int64{4, 3},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := Intersection(test.a, test.b)
+
+			if !reflect.DeepEqual(result, test.result) {
+				t.Errorf("result wrong\ngot:  %#v\nwant: %#v\n", result, test.result)
+			}
+		})
+	}
+}
+
 func BenchmarkComplement_equal(b *testing.B) {
 	listA := []int64{1, 2, 3}
 	listB := []int64{1, 2, 3}


### PR DESCRIPTION
wasn't sure if I should name this `Intersection` or `Common` or something.
basically we were accompishing this in a few places via:
```
assigneesToNotify = sliceutil.FilterInt(assigneesToNotify, func(n int64) bool {
    return sliceutil.InInt64Slice(privacyUserIDs, n)
})
followersToNotifyEmail = sliceutil.FilterInt(followersToNotifyEmail, func(n int64) bool {
    return sliceutil.InInt64Slice(privacyUserIDs, n)
})
followersToNotifyTwIM = sliceutil.FilterInt(followersToNotifyTwIM, func(n int64) bool {
    return sliceutil.InInt64Slice(privacyUserIDs, n)
})
```
which works, but isn't ideal from a performance perspective since it could involve a lot of iterations.