### PR TITLE
Enhancement: DetachContext and Generic sync.Map

### DIFF
--- a/contextutil/detachcontext.go
+++ b/contextutil/detachcontext.go
@@ -1,4 +1,4 @@
-package syncutil
+package contextutil
 
 import (
 	"context"
@@ -11,6 +11,7 @@ type detachedContext struct {
 }
 
 // Deadline returns the time when work done on behalf of this context
+// should be canceled. In a detached context, it will always return false.
 func (d detachedContext) Deadline() (time.Time, bool) {
 	return time.Time{}, false
 }
@@ -20,12 +21,18 @@ func (d detachedContext) Done() <-chan struct{} {
 	return nil
 }
 
-// Err returns nil always.
+// If Done is not yet closed, Err returns nil.
+// If Done is closed, Err returns a non-nil error explaining why:
+// Canceled if the context was canceled
+// or DeadlineExceeded if the context's deadline passed.
+// In a detached context, it will always return false.
 func (d detachedContext) Err() error {
 	return nil
 }
 
-// Value returns the value associated with this context for key, or nil if no
+// Value returns the value associated with this context for key, or nil
+// if no value is associated with key. Successive calls to Value with
+// the same key returns the same result.
 func (d detachedContext) Value(key interface{}) interface{} {
 	return d.ctx.Value(key)
 }

--- a/contextutil/detachcontext.go
+++ b/contextutil/detachcontext.go
@@ -11,22 +11,23 @@ type detachedContext struct {
 	ctx context.Context
 }
 
-// Deadline returns the time when work done on behalf of this context
-// should be canceled. In a detached context, it will always return false.
+// Deadline returns a zeroed time and false.
+// Refer to `context.Context.Deadline` for an explanation of what `Deadline`
+// usually does.
 func (d detachedContext) Deadline() (time.Time, bool) {
 	return time.Time{}, false
 }
 
-// Done returns a nil channel always.
+// Done always returns a nil channel.
+// Refer to `context.Context.Done` for an explanation of what `Done`
+// usually does.
 func (d detachedContext) Done() <-chan struct{} {
 	return nil
 }
 
-// If Done is not yet closed, Err returns nil.
-// If Done is closed, Err returns a non-nil error explaining why:
-// Canceled if the context was canceled
-// or DeadlineExceeded if the context's deadline passed.
-// In a detached context, it will always return false.
+// Err always returns nil.
+// Refer to `context.Context.Err` for an explanation of what `Err`
+// usually does.
 func (d detachedContext) Err() error {
 	return nil
 }

--- a/contextutil/detachcontext.go
+++ b/contextutil/detachcontext.go
@@ -1,4 +1,5 @@
-package contextutil
+// Package contextutil adds functions for context.
+package contextutil // import "github.com/teamwork/utils/v2/contextutil"
 
 import (
 	"context"

--- a/contextutil/detachcontext_test.go
+++ b/contextutil/detachcontext_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestDetach(t *testing.T) {
+	t.Parallel()
 	type myCoolKey struct{}
 
 	pCtx := context.WithValue(context.Background(), myCoolKey{}, 56)

--- a/contextutil/detachcontext_test.go
+++ b/contextutil/detachcontext_test.go
@@ -1,0 +1,37 @@
+package contextutil_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/teamwork/utils/v2/contextutil"
+)
+
+func TestDetach(t *testing.T) {
+	type myCoolKey struct{}
+
+	pCtx := context.WithValue(context.Background(), myCoolKey{}, 56)
+
+	pCtx, cancel := context.WithDeadline(pCtx, time.Now().AddDate(0, 0, -1))
+	defer cancel()
+
+	ctx := contextutil.DetachContext(pCtx)
+
+	if pCtx.Err() == nil {
+		t.Fatal("expected err")
+	}
+	if ctx.Err() != nil {
+		t.Fatal("expected nil err")
+	}
+	if pCtx.Done() == nil {
+		t.Fatal("expected done channel")
+	}
+	if ctx.Done() != nil {
+		t.Fatal("expected nil done channel")
+	}
+
+	if ctx.Value(myCoolKey{}).(int) != 56 {
+		t.Fatal("expected to retrieve value 56")
+	}
+}

--- a/goutil/goutil_test.go
+++ b/goutil/goutil_test.go
@@ -71,6 +71,7 @@ func TestExpand(t *testing.T) {
 			[]string{
 				"github.com/teamwork/utils/v2",
 				"github.com/teamwork/utils/v2/aesutil",
+				"github.com/teamwork/utils/v2/contextutil",
 				"github.com/teamwork/utils/v2/dbg",
 				"github.com/teamwork/utils/v2/errorutil",
 				"github.com/teamwork/utils/v2/goutil",

--- a/syncutil/detach.go
+++ b/syncutil/detach.go
@@ -1,0 +1,38 @@
+package syncutil
+
+import (
+	"context"
+	"time"
+)
+
+// detachedContext is a context that is detached from the parent context.
+type detachedContext struct {
+	ctx context.Context
+}
+
+// Deadline returns the time when work done on behalf of this context
+func (d detachedContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+// Done returns a nil channel always.
+func (d detachedContext) Done() <-chan struct{} {
+	return nil
+}
+
+// Err returns nil always.
+func (d detachedContext) Err() error {
+	return nil
+}
+
+// Value returns the value associated with this context for key, or nil if no
+func (d detachedContext) Value(key interface{}) interface{} {
+	return d.ctx.Value(key)
+}
+
+// DetachContext returns a context that is detached from the parent context.
+// This is useful when you want to run a function in a goroutine that will
+// outlive the parent context.
+func DetachContext(ctx context.Context) context.Context {
+	return detachedContext{ctx}
+}

--- a/syncutil/syncmap.go
+++ b/syncutil/syncmap.go
@@ -1,6 +1,8 @@
 package syncutil
 
-import "sync"
+import (
+	"sync"
+)
 
 // Map a generic sync map.
 type Map[K comparable, V any] struct {

--- a/syncutil/syncmap.go
+++ b/syncutil/syncmap.go
@@ -1,4 +1,4 @@
-package syncmap
+package syncutil
 
 import "sync"
 

--- a/syncutil/syncmap.go
+++ b/syncutil/syncmap.go
@@ -1,0 +1,52 @@
+package syncmap
+
+import "sync"
+
+// Map a generic sync map.
+type Map[K comparable, V any] struct {
+	mx *sync.RWMutex
+	m  map[K]V
+}
+
+// NewMap create a new threadsafe map.
+func NewMap[K comparable, V any]() Map[K, V] {
+	return Map[K, V]{
+		mx: &sync.RWMutex{},
+		m:  make(map[K]V),
+	}
+}
+
+// Get a value from this map.
+func (sm *Map[K, V]) Get(k K) (V, bool) {
+	sm.mx.RLock()
+	defer sm.mx.RUnlock()
+	v, ok := sm.m[k]
+	return v, ok
+}
+
+// Store a value in this map.
+func (sm *Map[K, V]) Store(k K, v V) {
+	sm.mx.Lock()
+	defer sm.mx.Unlock()
+	sm.m[k] = v
+}
+
+// Range iterate the map.
+func (sm *Map[K, V]) Range(fn func(K, V) bool) {
+	cm := func() map[K]V {
+		sm.mx.RLock()
+		defer sm.mx.RUnlock()
+		copyMap := make(map[K]V, len(sm.m))
+		for k, v := range sm.m {
+			copyMap[k] = v
+		}
+
+		return copyMap
+	}()
+
+	for k, v := range cm {
+		if !fn(k, v) {
+			break
+		}
+	}
+}

--- a/syncutil/syncmap_test.go
+++ b/syncutil/syncmap_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestMap_Store(t *testing.T) {
+	t.Parallel()
 	tests := map[string]int{
 		"hello": 4,
 		"world": 7,
@@ -34,6 +35,7 @@ func TestMap_Store(t *testing.T) {
 }
 
 func TestMap_Store_Concurrent(t *testing.T) {
+	t.Parallel()
 	m := syncutil.NewMap[string, int]()
 	for i := 0; i < 10000; i++ {
 		i := i
@@ -44,6 +46,7 @@ func TestMap_Store_Concurrent(t *testing.T) {
 }
 
 func TestMap_Range(t *testing.T) {
+	t.Parallel()
 	base := map[string]int{
 		"hello":    1,
 		"world":    2,
@@ -85,6 +88,7 @@ func TestMap_Range(t *testing.T) {
 }
 
 func TestMap_Range_EarlyReturn(t *testing.T) {
+	t.Parallel()
 	m := syncutil.NewMap[string, int]()
 	m.Store("test", 1)
 	m.Store("wow", 2)

--- a/syncutil/syncmap_test.go
+++ b/syncutil/syncmap_test.go
@@ -1,0 +1,102 @@
+package syncutil_test
+
+import (
+	"testing"
+
+	"github.com/teamwork/utils/v2/syncutil"
+)
+
+func TestMap_Store(t *testing.T) {
+	tests := map[string]int{
+		"hello": 4,
+		"world": 7,
+		"ohwow": 10,
+	}
+
+	m := syncutil.NewMap[string, int]()
+	for name, value := range tests {
+		name := name
+		value := value
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m.Store(name, value)
+
+			got, ok := m.Get(name)
+			if !ok {
+				t.Fatalf("key '%s' expected 'true' got 'false'", name)
+			}
+			if value != got {
+				t.Fatalf("key '%s' expected '%d' got '%d'", name, value, got)
+			}
+		})
+	}
+}
+
+func TestMap_Store_Concurrent(t *testing.T) {
+	m := syncutil.NewMap[string, int]()
+	for i := 0; i < 10000; i++ {
+		i := i
+		go func() {
+			m.Store("hello", i)
+		}()
+	}
+}
+
+func TestMap_Range(t *testing.T) {
+	base := map[string]int{
+		"hello":    1,
+		"world":    2,
+		"wow":      3,
+		"holyhell": 4,
+	}
+	test := map[string]bool{
+		"hello":    false,
+		"world":    false,
+		"wow":      false,
+		"holyhell": false,
+	}
+
+	m := syncutil.NewMap[string, int]()
+	for k, v := range base {
+		m.Store(k, v)
+	}
+
+	m.Range(func(k string, v int) bool {
+		seen, ok := test[k]
+		if !ok {
+			t.Fatalf("unexpected key '%s'", k)
+		}
+
+		if seen {
+			t.Fatalf("duplicate range '%s'", k)
+		}
+
+		test[k] = true
+
+		return true
+	})
+
+	for k, v := range test {
+		if !v {
+			t.Fatalf("missed key '%s'", k)
+		}
+	}
+}
+
+func TestMap_Range_EarlyReturn(t *testing.T) {
+	m := syncutil.NewMap[string, int]()
+	m.Store("test", 1)
+	m.Store("wow", 2)
+
+	var count int
+
+	m.Range(func(k string, v int) bool {
+		count++
+		return false
+	})
+
+	if count != 1 {
+		t.Fatalf("unexpected count '%d'", count)
+	}
+}


### PR DESCRIPTION
I've a SyncMap implementation [here](https://github.com/Teamwork/go-bdd/blob/main/internal/syncmap/map.go) that would be great to centralise.

Also a detachcontext implementation was added into apigo that would also be great to make general until go adds it to the standard library.