### PR TITLE
Fix: Add missing predeclared types

### DIFF
--- a/goutil/goutil.go
+++ b/goutil/goutil.go
@@ -69,7 +69,6 @@ func ResolvePackage(path string, mode build.ImportMode) (pkg *build.Package, err
 		if err != nil {
 			return nil, err
 		}
-		fmt.Println(path)
 		pkg, err = build.ImportDir(path, mode)
 	default:
 		if cwd == "" {
@@ -266,7 +265,7 @@ start:
 // https://golang.org/ref/spec#Predeclared_identifiers
 func PredeclaredType(n string) bool {
 	switch n {
-	case "bool", "byte", "complex64", "complex128", "error", "float32",
+	case "any", "bool", "byte", "comparable", "complex64", "complex128", "error", "float32",
 		"float64", "int", "int8", "int16", "int32", "int64", "rune", "string",
 		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr":
 		return true

--- a/goutil/goutil_test.go
+++ b/goutil/goutil_test.go
@@ -227,7 +227,7 @@ func TestTagName(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%v", tc.in), func(t *testing.T) {
 			f := &ast.Field{
-				Names: []*ast.Ident{&ast.Ident{Name: "Original"}},
+				Names: []*ast.Ident{{Name: "Original"}},
 				Tag:   &ast.BasicLit{Value: fmt.Sprintf("`%v`", tc.in)}}
 
 			out := TagName(f, tc.inName)
@@ -239,7 +239,7 @@ func TestTagName(t *testing.T) {
 
 	t.Run("nil", func(t *testing.T) {
 		f := &ast.Field{
-			Names: []*ast.Ident{&ast.Ident{Name: "Original"}},
+			Names: []*ast.Ident{{Name: "Original"}},
 		}
 
 		out := TagName(f, "json")
@@ -260,8 +260,8 @@ func TestTagName(t *testing.T) {
 		}()
 
 		f := &ast.Field{
-			Names: []*ast.Ident{&ast.Ident{Name: "Original"},
-				&ast.Ident{Name: "Second"}}}
+			Names: []*ast.Ident{{Name: "Original"},
+				{Name: "Second"}}}
 		_ = TagName(f, "json")
 	})
 


### PR DESCRIPTION
Recent versions of the compiler added `any` and `comparable`.