### PR TITLE
Add JoinWith

### DIFF
--- a/sliceutil/sliceutil.go
+++ b/sliceutil/sliceutil.go
@@ -18,12 +18,17 @@ import (
 // Join converts a slice of T to a comma separated string. Useful for
 // inserting into a query without the option of parameterization.
 func Join[T any](tt []T) string {
-	var str []string
-	for _, t := range tt {
-		str = append(str, fmt.Sprintf("%v", t))
+	return JoinWith(tt, ", ")
+}
+
+// JoinWith converts a slice of T to a string using the provided delim.
+func JoinWith[T any](tt []T, delim string) string {
+	str := make([]string, len(tt))
+	for i, t := range tt {
+		str[i] = fmt.Sprintf("%v", t)
 	}
 
-	return strings.Join(str, ", ")
+	return strings.Join(str, delim)
 }
 
 // Unique removes duplicate entries from a list. The list does not have to be sorted.

--- a/sliceutil/sliceutil_test.go
+++ b/sliceutil/sliceutil_test.go
@@ -43,25 +43,39 @@ func TestJoin(t *testing.T) {
 func TestJoinWith(t *testing.T) {
 	cases := []struct {
 		in       []int64
+		delim    string
 		expected string
 	}{
 		{
 			[]int64{1, 2, 3, 4, 4, 5, 6, 6, 6, 6, 7, 8, 8, 8},
+			" || ",
 			"1 || 2 || 3 || 4 || 4 || 5 || 6 || 6 || 6 || 6 || 7 || 8 || 8 || 8",
 		},
 		{
+			[]int64{1, 2, 3, 4, 4, 5, 6, 6, 6, 6, 7, 8, 8, 8},
+			",",
+			"1,2,3,4,4,5,6,6,6,6,7,8,8,8",
+		},
+		{
 			[]int64{-1, -2, -3, -4, -4, -5, -6, -6, -6, -6, -7, -8, -8, -8},
+			" || ",
 			"-1 || -2 || -3 || -4 || -4 || -5 || -6 || -6 || -6 || -6 || -7 || -8 || -8 || -8",
 		},
 		{
+			[]int64{-1, -2, -3, -4, -4, -5, -6, -6, -6, -6, -7, -8, -8, -8},
+			",",
+			"-1,-2,-3,-4,-4,-5,-6,-6,-6,-6,-7,-8,-8,-8",
+		},
+		{
 			[]int64{},
+			" || ",
 			"",
 		},
 	}
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("test-%v", i), func(t *testing.T) {
-			got := JoinWith(tc.in, " || ")
+			got := JoinWith(tc.in, tc.delim)
 			if got != tc.expected {
 				t.Errorf(diff.Cmp(tc.expected, got))
 			}

--- a/sliceutil/sliceutil_test.go
+++ b/sliceutil/sliceutil_test.go
@@ -40,6 +40,35 @@ func TestJoin(t *testing.T) {
 	}
 }
 
+func TestJoinWith(t *testing.T) {
+	cases := []struct {
+		in       []int64
+		expected string
+	}{
+		{
+			[]int64{1, 2, 3, 4, 4, 5, 6, 6, 6, 6, 7, 8, 8, 8},
+			"1 || 2 || 3 || 4 || 4 || 5 || 6 || 6 || 6 || 6 || 7 || 8 || 8 || 8",
+		},
+		{
+			[]int64{-1, -2, -3, -4, -4, -5, -6, -6, -6, -6, -7, -8, -8, -8},
+			"-1 || -2 || -3 || -4 || -4 || -5 || -6 || -6 || -6 || -6 || -7 || -8 || -8 || -8",
+		},
+		{
+			[]int64{},
+			"",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("test-%v", i), func(t *testing.T) {
+			got := JoinWith(tc.in, " || ")
+			if got != tc.expected {
+				t.Errorf(diff.Cmp(tc.expected, got))
+			}
+		})
+	}
+}
+
 func TestUniq_Int64(t *testing.T) {
 	cases := []struct {
 		in       []int64


### PR DESCRIPTION
Sometimes I don't want "1, 2, 3" and instead want "1,2,3".

(There are a good few instances of `sliceutil.Join` being wrapped in `strings.ReplaceAll(s, " ", "")`)