### PR TITLE
Feat: expand mathutil to add CeilPlus

### DIFF
--- a/mathutil/mathutil.go
+++ b/mathutil/mathutil.go
@@ -26,7 +26,7 @@ func RoundPlus(f float64, precision int) float64 {
 
 // CeilPlus will ceil the value to the given precision.
 //
-// e.g. RoundPlus(123.233333, 2) will return 123.24
+// e.g. CeilPlus(123.233333, 2) will return 123.24
 func CeilPlus(f float64, precision int) float64 {
 	multiplier := math.Pow10(precision)
 	return math.Ceil(f*multiplier) / multiplier

--- a/mathutil/mathutil.go
+++ b/mathutil/mathutil.go
@@ -24,6 +24,14 @@ func RoundPlus(f float64, precision int) float64 {
 	return Round(f*shift) / shift
 }
 
+// CeilPlus will ceil the value to the given precision.
+//
+// e.g. RoundPlus(123.233333, 2) will return 123.24
+func CeilPlus(f float64, precision int) float64 {
+	multiplier := math.Pow10(precision)
+	return math.Ceil(f*multiplier) / multiplier
+}
+
 // Min gets the lowest of two numbers.
 func Min(a, b int64) int64 {
 	if a > b {

--- a/mathutil/mathutil_test.go
+++ b/mathutil/mathutil_test.go
@@ -37,6 +37,7 @@ func TestRoundPlus(t *testing.T) {
 		{123.555555, 3, 123.556},
 		{123.558, 2, 123.56},
 		{-123.555555, 3, -123.556},
+		{123.233333, 2, 123.23},
 	}
 
 	for _, c := range cases {
@@ -46,6 +47,27 @@ func TestRoundPlus(t *testing.T) {
 		}
 	}
 
+}
+
+func TestCeilPlus(t *testing.T) {
+	cases := []struct {
+		in        float64
+		precision int
+		want      float64
+	}{
+		{123.554999, 3, 123.555},
+		{123.555555, 3, 123.556},
+		{123.558, 2, 123.56},
+		{-123.555555, 3, -123.555},
+		{123.233333, 2, 123.24},
+	}
+
+	for _, c := range cases {
+		got := CeilPlus(c.in, c.precision)
+		if got != c.want {
+			t.Errorf("Round(%f) => %f, want %f", c.in, got, c.want)
+		}
+	}
 }
 
 func TestIsSignedZero(t *testing.T) {

--- a/mathutil/mathutil_test.go
+++ b/mathutil/mathutil_test.go
@@ -65,7 +65,7 @@ func TestCeilPlus(t *testing.T) {
 	for _, c := range cases {
 		got := CeilPlus(c.in, c.precision)
 		if got != c.want {
-			t.Errorf("Round(%f) => %f, want %f", c.in, got, c.want)
+			t.Errorf("CeilPlus(%f) => %f, want %f", c.in, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
New function that we need in some scenarios where we want to return the ceil based on a precision level. For example, the cost of a timelog could be 58.23333, and we want to round it based on the currency decimals. For example in EUR, 58.24