### PR TITLE
Fix: HTTP - Exponential Backoff - Expose error after reaching all attempts

### DIFF
--- a/httputilx/httputilx.go
+++ b/httputilx/httputilx.go
@@ -245,7 +245,7 @@ func DoExponentialBackoff(req *http.Request, options ...ExponentialBackoffOption
 
 		resp, err := o.client.Do(reqClone)
 		if !o.shouldRetry(resp, err) || attempt >= o.maxRetries {
-			return resp, nil
+			return resp, err
 		}
 
 		logArgs := []any{


### PR DESCRIPTION
When reaching the maximum number of attempts, the error should be exposed to the caller.

Related to: https://github.com/Teamwork/utils/pull/87